### PR TITLE
LIBITD-568. Make availability selection a big grid of check_boxes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,9 +36,9 @@ gem 'capistrano-rails', group: :development
 gem 'umd_lib_style', github: 'umd-lib/umd_lib_style', branch: 'develop'
 gem 'rack-cas'
 
-gem "simple_form"
-gem "cocoon"
-gem "country_select"
+gem 'simple_form'
+gem 'cocoon'
+gem 'country_select'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -36,8 +36,9 @@ gem 'capistrano-rails', group: :development
 gem 'umd_lib_style', github: 'umd-lib/umd_lib_style', branch: 'develop'
 gem 'rack-cas'
 
-gem 'bootstrap_form'
-gem 'nested_form'
+gem "simple_form"
+gem "cocoon"
+gem "country_select"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,6 @@ GEM
     ast (2.3.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bootstrap_form (2.5.2)
     builder (3.2.2)
     byebug (9.0.6)
     capistrano (3.6.1)
@@ -73,7 +72,7 @@ GEM
       capistrano (~> 3.1)
       sshkit (~> 1.2)
     capistrano-harrow (0.5.3)
-    capistrano-rails (1.1.8)
+    capistrano-rails (1.2.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capybara (2.10.1)
@@ -84,9 +83,17 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     cliver (0.3.2)
+    cocoon (1.2.9)
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
     connection_pool (2.2.0)
+    countries (1.2.5)
+      currencies (~> 0.4.2)
+      i18n_data (~> 0.7.0)
+    country_select (2.5.2)
+      countries (~> 1.2.0)
+      sort_alphabetical (~> 1.0)
+    currencies (0.4.2)
     debug_inspector (0.0.2)
     docile (1.1.5)
     erubis (2.7.0)
@@ -109,6 +116,7 @@ GEM
       guard-compat (~> 1.2)
       minitest (>= 3.0)
     i18n (0.7.0)
+    i18n_data (0.7.0)
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -149,7 +157,7 @@ GEM
       minitest-capybara (~> 0.8)
       minitest-metadata (~> 0.6)
       minitest-rails (~> 2.1)
-    minitest-reporters (1.1.11)
+    minitest-reporters (1.1.12)
       ansi
       builder
       minitest (>= 5.0)
@@ -158,7 +166,6 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.12.1)
     nenv (0.3.0)
-    nested_form (0.3.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.2.0)
@@ -217,7 +224,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
     rake (11.3.0)
-    rb-fsevent (0.9.7)
+    rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     rdoc (4.2.2)
@@ -244,12 +251,17 @@ GEM
     shoulda-context (1.2.1)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
+    simple_form (3.3.1)
+      actionpack (> 4, < 5.1)
+      activemodel (> 4, < 5.1)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
+    sort_alphabetical (1.0.2)
+      unicode_utils (>= 1.2.2)
     spring (2.0.0)
       activesupport (>= 4.2)
     sprockets (3.7.0)
@@ -274,9 +286,10 @@ GEM
     turbolinks-source (5.0.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (3.0.2)
+    uglifier (3.0.3)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.1.1)
+    unicode_utils (1.4.0)
     web-console (2.3.0)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
@@ -292,11 +305,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bootstrap_form
   byebug
   capistrano-rails
   capybara-screenshot!
+  cocoon
   connection_pool
+  country_select
   guard
   guard-minitest
   jbuilder (~> 2.0)
@@ -305,7 +319,6 @@ DEPENDENCIES
   minitest-rails-capybara
   minitest-reporters
   mocha
-  nested_form
   pg
   poltergeist
   pry-rails
@@ -319,6 +332,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   shoulda-context
   shoulda-matchers (>= 3.0.1)
+  simple_form
   simplecov
   spring
   sqlite3

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
-//= require jquery_nested_form
+//= require cocoon
 //= require_tree .
 //= require umd_lib

--- a/app/assets/javascripts/prospect.js
+++ b/app/assets/javascripts/prospect.js
@@ -26,5 +26,17 @@ $(document).ready(function() {
     
     } 
   });  
+  
+  $(".availability-table > tbody > tr > td  input").hide();
+
+  $(".availability-table > tbody > tr > td ").on("click", function(event) {
+    var $this = $(this); 
+    var checkbox =  $this.find("input");
+    checkbox.prop("checked", !checkbox.prop("checked"));
+    $this.toggleClass("success");
+    $this.toggleClass("warning"); 
+  
+  })
+
 
 })

--- a/app/assets/javascripts/prospect.js
+++ b/app/assets/javascripts/prospect.js
@@ -27,15 +27,15 @@ $(document).ready(function() {
     } 
   });  
   
-  $(".availability-table > tbody > tr > td  input").hide();
+  $("#availability-table > tbody > tr > td  input").hide();
 
-  $(".availability-table > tbody > tr > td ").on("click", function(event) {
+  $("#availability-table > tbody > tr > td:not(.time-label) ").on("click", function(event) {
     var $this = $(this); 
-    var checkbox =  $this.find("input");
-    checkbox.prop("checked", !checkbox.prop("checked"));
     $this.toggleClass("success");
     $this.toggleClass("warning"); 
-  
+    
+    var checkbox =  $this.find("input");
+    checkbox.prop("checked", !checkbox.prop("checked"));
   })
 
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,22 +12,20 @@
  *
  *= require_tree .
  *= require 'umd_lib'
- *= require rails_bootstrap_forms
  *= require_self
  */
 
 #home-jumbo { margin-top: 50px }
 
-label.required:after {
-  content:" *";
-  color: red;
+label.required abbr {
+  color: #a94442;
 }
 
 
 
 .panel-heading { min-height: 53px }
 .panel-heading span { font-size: 22px  }
-.fields {
+.nested-fields {
   border-bottom: 1px solid transparent;
   border-color: #ddd;
   margin: 15px 0px;
@@ -36,3 +34,8 @@ label.required:after {
 
 .form-horizontal  .radio-inline { padding-top: 0px  }
 .radio-question { padding-right: 20px; vertical-align: middle; }
+
+
+
+
+

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -35,6 +35,16 @@ label.required abbr {
 .form-horizontal  .radio-inline { padding-top: 0px  }
 .radio-question { padding-right: 20px; vertical-align: middle; }
 
+#availability-table > thead > tr > th, #availability-table > tbody > tr >  td { text-align: center;  width: 13.2%; padding: 8px 0px }
+#availability-table th.time-label, #availability-table td.time-label { position: relative; padding: 8px 0px; width: 6.6% }
+#availability-table > tbody > tr >  td:not(.time-label) { cursor: pointer; }
+#availability-table > tbody > tr >  td:not(.time-label):hover { background-color: #dff0d8; border: 2px groove #dff0d8; }
+#availability-table .time-label > span { 
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding-right: 2px;
+ }
 
 
 

--- a/app/controllers/prospects_controller.rb
+++ b/app/controllers/prospects_controller.rb
@@ -48,14 +48,14 @@ class ProspectsController < ApplicationController
       # this is just a sanity check since sometimes we don't actually have
       # anything to add when using the back button. If we don't have a prospect
       # param, we just go to the step in session. if we don't have a session,
-      # we just go to first step. 
-      params[:prospect] ||=  { current_step: ( session[:prospect_step] || Prospect.steps.first  ) } 
-      whitelisted_attrs = %i( current_step commit has_family_member in_federal_study directory_id first_name last_name local_address 
-                       local_phone perm_address perm_phone email family_member class_status
-                       graduation_year additional_comments ) 
+      # we just go to first step.
+      params[:prospect] ||= { current_step: (session[:prospect_step] || Prospect.steps.first) }
+      whitelisted_attrs = %i( current_step commit has_family_member in_federal_study directory_id first_name last_name local_address
+                              local_phone perm_address perm_phone email family_member class_status
+                              graduation_year additional_comments )
       whitelisted_attrs << { day_times: [],
-                            skills_ids: [], skills: [ :id, :name, :_destroy ],
-                            work_experiences: [ :id, :name, :_destroy ] } 
+                             skills_ids: [], skills: [:id, :name, :_destroy],
+                             work_experiences: [:id, :name, :_destroy] }
       params.require(:prospect).permit(*whitelisted_attrs).tap do |wl|
         %i(addresses_attributes work_experiences_attributes available_times_attributes).each do |attr_group_key|
           unless params[:prospect][attr_group_key].blank?

--- a/app/controllers/prospects_controller.rb
+++ b/app/controllers/prospects_controller.rb
@@ -48,8 +48,14 @@ class ProspectsController < ApplicationController
       # this is just a sanity check since sometimes we don't actually have
       # anything to add when using the back button. If we don't have a prospect
       # param, we just go to the step in session. if we don't have a session,
-      # we just go to first step.
-      params[:prospect] ||= { current_step: (session[:prospect_step] || Prospect.steps.first) }
+      # we just go to first step. 
+      params[:prospect] ||=  { current_step: ( session[:prospect_step] || Prospect.steps.first  ) } 
+      whitelisted_attrs = %i( current_step commit has_family_member in_federal_study directory_id first_name last_name local_address 
+                       local_phone perm_address perm_phone email family_member class_status
+                       graduation_year additional_comments ) 
+      whitelisted_attrs << { day_times: [],
+                            skills_ids: [], skills: [ :id, :name, :_destroy ],
+                            work_experiences: [ :id, :name, :_destroy ] } 
       params.require(:prospect).permit(*whitelisted_attrs).tap do |wl|
         %i(addresses_attributes work_experiences_attributes available_times_attributes).each do |attr_group_key|
           unless params[:prospect][attr_group_key].blank?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,40 +1,52 @@
 module ApplicationHelper
+  # takes an 24 hour integer and formcats it into "HHam/pm".
+  # like 13 => 1pm
+  def hour_integer_to_humanized(time)
+    Time.strptime(time.to_s, '%H').strftime('%l%P')
+  end
 
-
-  # take a time and returns string that 
+  # take a time and returns string that
   # represents a one hour time range
   def hour_integer_to_range(time)
-    startt = Time.strptime( time.to_s, "%H").strftime("%I-")
-    endt =  Time.strptime( ( time + 1 ).to_s, "%H").strftime("%I:%M %P")
+    startt = Time.strptime(time.to_s, '%H').strftime('%l-')
+    endt = Time.strptime((time + 1).to_s, '%H').strftime('%l:%M %P')
     "#{startt}#{endt}"
   end
-  
-  def availablity_table(form)
-    thead = content_tag(:thead) do 
-        content_tag(:tr)do
-          concat content_tag(:th, "") 
-          AvailableTime.days.keys.collect { |d| concat content_tag(:th, d.capitalize) }
-        end 
-    end
-    
-    tbody = content_tag :tbody do
-      (0..23).collect do |hour|   
-        concat(content_tag(:tr, class: "table-active") do
-          
-          concat content_tag(:td, hour_integer_to_range(hour)) 
-          AvailableTime.days.collect do |day| 
-            concat(  
-              form.input(:day_times,  include_hidden: false,  label: false, wrapper: false  ) do 
-                form.collection_check_boxes :day_times, ["#{day.last}-#{hour}"], 
-                  :to_s, :to_s, { include_hidden: false, multiple: true }   do |cb|
-                    content_tag(:td, class: form.object.day_times.include?(cb.object) ? "success" : "warning" ) { cb.label { cb.check_box } }
-                end
-                end)
-          end
-        end)
-      end 
-    end 
-    content_tag(:table, :class => "table table-bordered availability-table") { thead.concat(tbody) } 
+
+  # this returns the css class used in the cell of the avail table
+  def avail_table_cell_status(form, value)
+    form.object.day_times.include?(value) ? 'success' : 'warning'
   end
 
+  def availablity_table(form)
+    thead = content_tag(:thead) do
+      content_tag(:tr) do
+        concat content_tag(:th, '', class: 'time-label')
+        AvailableTime.days.keys.collect { |d| concat content_tag(:th, d.capitalize) }
+      end
+    end
+
+    tbody = content_tag :tbody do
+      (0..23).collect do |hour|
+        concat(content_tag(:tr, class: 'table-active') do
+          concat(content_tag(:td, class: 'time-label') do
+            content_tag(:span) { hour_integer_to_humanized(hour) }
+          end)
+          AvailableTime.days.collect do |day|
+            concat(
+              form.input(:day_times, include_hidden: false, label: false, wrapper: false) do
+                form.collection_check_boxes :day_times, ["#{day.last}-#{hour}"],
+                                            :to_s, :to_s, include_hidden: false, multiple: true do |cb|
+                  content_tag(:td, class: avail_table_cell_status(form, cb.object).to_s) do
+                    cb.label { cb.check_box }
+                  end
+                end
+              end
+            )
+          end
+        end)
+      end
+    end
+    content_tag(:table, class: 'table table-bordered', id: 'availability-table') { thead.concat(tbody) }
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,40 @@
 module ApplicationHelper
+
+
+  # take a time and returns string that 
+  # represents a one hour time range
+  def hour_integer_to_range(time)
+    startt = Time.strptime( time.to_s, "%H").strftime("%I-")
+    endt =  Time.strptime( ( time + 1 ).to_s, "%H").strftime("%I:%M %P")
+    "#{startt}#{endt}"
+  end
+  
+  def availablity_table(form)
+    thead = content_tag(:thead) do 
+        content_tag(:tr)do
+          concat content_tag(:th, "") 
+          AvailableTime.days.keys.collect { |d| concat content_tag(:th, d.capitalize) }
+        end 
+    end
+    
+    tbody = content_tag :tbody do
+      (0..23).collect do |hour|   
+        concat(content_tag(:tr, class: "table-active") do
+          
+          concat content_tag(:td, hour_integer_to_range(hour)) 
+          AvailableTime.days.collect do |day| 
+            concat(  
+              form.input(:day_times,  include_hidden: false,  label: false, wrapper: false  ) do 
+                form.collection_check_boxes :day_times, ["#{day.last}-#{hour}"], 
+                  :to_s, :to_s, { include_hidden: false, multiple: true }   do |cb|
+                    content_tag(:td, class: form.object.day_times.include?(cb.object) ? "success" : "warning" ) { cb.label { cb.check_box } }
+                end
+                end)
+          end
+        end)
+      end 
+    end 
+    content_tag(:table, :class => "table table-bordered availability-table") { thead.concat(tbody) } 
+  end
+
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,7 +4,7 @@ class Address < ActiveRecord::Base
   validates :prospect, presence: true
   enum address_type: %i(local permanent)
 
-  %i(street_address_1 city state postal_code address_type).each do |attr|
+  %i(street_address_1 city  postal_code address_type).each do |attr|
     validates attr, presence: true, if: ->(a) { a.prospect && a.prospect.current_step == 'contact_info' }
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,7 +4,7 @@ class Address < ActiveRecord::Base
   validates :prospect, presence: true
   enum address_type: %i(local permanent)
 
-  %i(street_address_1 city  postal_code address_type).each do |attr|
+  %i(street_address_1 city postal_code address_type).each do |attr|
     validates attr, presence: true, if: ->(a) { a.prospect && a.prospect.current_step == 'contact_info' }
   end
 end

--- a/app/models/available_day.rb
+++ b/app/models/available_day.rb
@@ -1,5 +1,0 @@
-# Days of the week the applicant is available work
-class AvailableDay < ActiveRecord::Base
-  belongs_to :available_time
-  enum day: %i(sunday monday tuesday wednesday thursday friday saturday)
-end

--- a/app/models/available_time.rb
+++ b/app/models/available_time.rb
@@ -1,41 +1,10 @@
 # Times of day the applicant is available to work
 class AvailableTime < ActiveRecord::Base
-  has_many :available_days
-  accepts_nested_attributes_for :available_days, allow_destroy: true
+  enum day: %i{ sunday monday tuesday wednesday thursday friday saturday } 
 
-  # keeps rails from freaking out.
-  attr_accessor :days
-
-  def initialize(attributes = nil, options = {})
-    unless attributes.nil? || attributes[:days].blank?
-      Array.wrap(attributes[:days]).flatten.reject(&:blank?)
-    end
-    super
+  attr_writer :day_time
+  def day_time
+    "#{AvailableTime.days[day]}-#{time}"
   end
 
-  # This allows us to create available days by passing in the day name to the
-  # object
-  def days=(names = [])
-    names = Array.wrap(names).flatten.reject(&:blank?)
-
-    day_attrs = []
-    # if there's a day not in out map, we mark it for delete
-    day_attrs << available_days.map { |ad| { id: ad.id, "_destroy": 1 } unless names.include?(ad.day) }
-
-    ## now any incoming days that are not already in the db
-    # first we mark all available days for delete
-    current_days = available_days.map(&:day)
-    day_attrs << names.map { |n| { day: n } unless current_days.include?(n) }
-
-    # now set the attributes. note these changes won't take effect until #save is called.
-    day_attrs.flatten!
-    day_attrs.reject!(&:blank?)
-    self.available_days_attributes = day_attrs
-    days
-  end
-
-  # returns available_days as a list of day names
-  def days
-    Array.wrap(available_days.map(&:day)).compact
-  end
 end

--- a/app/models/available_time.rb
+++ b/app/models/available_time.rb
@@ -1,10 +1,9 @@
 # Times of day the applicant is available to work
 class AvailableTime < ActiveRecord::Base
-  enum day: %i{ sunday monday tuesday wednesday thursday friday saturday } 
+  enum day: %i(sunday monday tuesday wednesday thursday friday saturday)
 
   attr_writer :day_time
   def day_time
     "#{AvailableTime.days[day]}-#{time}"
   end
-
 end

--- a/app/models/prospect.rb
+++ b/app/models/prospect.rb
@@ -34,6 +34,21 @@ class Prospect < ActiveRecord::Base
   has_many :available_times
   accepts_nested_attributes_for :available_times, allow_destroy: true
 
+  # this is a way of feeding day-times into the prospect and have them stored
+  # in
+  attr_accessor :day_times
+  def day_times
+    @day_times || []
+  end
+  def day_times=(dts)
+    available_times.destroy_all 
+    dts.each do |dt|
+      day,time = dt.split("-").map(&:to_i)
+      available_times.find_or_initialize_by( day: day, time: time )
+    end
+    @day_times = available_times.map(&:day_time)
+  end
+
   has_many :addresses, inverse_of: :prospect
   accepts_nested_attributes_for :addresses, allow_destroy: true
   #  validates_associated :addresses, if: ->(o) { o.current_step == "contact_info" }
@@ -49,8 +64,8 @@ class Prospect < ActiveRecord::Base
 
   has_and_belongs_to_many :skills
   accepts_nested_attributes_for :skills
-  attr_accessor :skill_ids
-
+  attr_accessor :skills_ids
+  
   attr_accessor :has_family_member
   validates :family_member, presence: true, if: ->(o) { o.family_member? }
 

--- a/app/models/prospect.rb
+++ b/app/models/prospect.rb
@@ -40,11 +40,12 @@ class Prospect < ActiveRecord::Base
   def day_times
     @day_times || []
   end
+
   def day_times=(dts)
-    available_times.destroy_all 
+    available_times.destroy_all
     dts.each do |dt|
-      day,time = dt.split("-").map(&:to_i)
-      available_times.find_or_initialize_by( day: day, time: time )
+      day, time = dt.split('-').map(&:to_i)
+      available_times.find_or_initialize_by(day: day, time: time)
     end
     @day_times = available_times.map(&:day_time)
   end
@@ -65,7 +66,7 @@ class Prospect < ActiveRecord::Base
   has_and_belongs_to_many :skills
   accepts_nested_attributes_for :skills
   attr_accessor :skills_ids
-  
+
   attr_accessor :has_family_member
   validates :family_member, presence: true, if: ->(o) { o.family_member? }
 

--- a/app/views/prospects/_address_fields.html.erb
+++ b/app/views/prospects/_address_fields.html.erb
@@ -1,0 +1,10 @@
+<div class='address nested-fields'>
+  <%= link_to_remove_association "remove", f, { class: 'pull-right' } %>
+  <%= f.input :address_type, collection: Address.address_types.map(&:first), as: :select, required: true %>
+  <%= f.input :street_address_1, required: true %>
+  <%= f.input :street_address_2 %>
+  <%= f.input :city, required: true %>
+  <%= f.input :state %>
+  <%= f.input :postal_code, required: true %>
+  <%= f.input :country, priority: ["US"] %>
+</div>

--- a/app/views/prospects/_availability_step.html.erb
+++ b/app/views/prospects/_availability_step.html.erb
@@ -1,11 +1,5 @@
 <h2>Availability</h2>
 
-<%= form.fields_for :available_times do |avail| %>
-  <%= avail.collection_select :days, AvailableDay.days, :first, :first, { selected: avail.object.days },
-      { multiple: true, selected: [ "sunday" ] }
-    %> 
-  <%= avail.time_select :start %>
-  <%= avail.time_select :end %>
-  <%= avail.check_box :all_day %>
-<% end %>
-<p><%= form.link_to_add "Add Availability", :available_times %></p>
+<div class="table-responsive">
+  <%= availablity_table(form) %>
+</div>

--- a/app/views/prospects/_comments_confirmation_step.html.erb
+++ b/app/views/prospects/_comments_confirmation_step.html.erb
@@ -96,8 +96,8 @@
   <table class="table table-striped">
     <% @prospect.available_times.each do |available| %>
       <tr>
-        <td><%= available.days.map(&:capitalize).join(', ') %></td>
-        <td><%= available.start.strftime('%l%P') %>–<%= available.end.strftime('%l%P').lstrip %></td>
+        <td><%= available.day.capitalize %></td>
+        <td><%= hour_integer_to_range(available.time) %></td>
       </tr>
     <% end %>
   </table>

--- a/app/views/prospects/_contact_info_step.html.erb
+++ b/app/views/prospects/_contact_info_step.html.erb
@@ -3,32 +3,32 @@
 <div class='panel panel-default'>
   <div class="panel-heading"><span>Basic Information</span></div>
   <div class="panel-body" id="basic-info">
-    <%= form.text_field :first_name %>
-    <%= form.text_field :last_name %>
-    <%= form.text_field :email %>
-    <%= form.text_field :directory_id %>
-    <%= form.select :class_status, Prospect.class_statuses.map { |cs| [ cs.first.capitalize, cs.first ] } %>
-    <%= form.select :graduation_year, Prospect.graduation_years.map { |gy| [ gy.first.gsub("_", " ").upcase, gy.first ] } %>
+      <%= form.input :first_name, required: true %>
+      <%= form.input :last_name,  required: true %>
+      <%= form.input :email, required: true %>
+      <%= form.input :directory_id, required: true  %>
+      <%= form.input :class_status, collection: 
+        Prospect.class_statuses.map { |cs| [ cs.first.capitalize, cs.first ] },
+        as: :select, include_blank: false %>
+      <%= form.input :graduation_year, collection:
+          Prospect.graduation_years.map { |gy| [ gy.first.gsub("_", " ").upcase, gy.first ] },
+          as: :select, include_blank: false %>
   </div>
 </div>
 
 <div class='panel panel-default'>
   <div class="panel-heading"><span>Addresses</span>
     <span class='pull-right'>
-      <%= form.link_to_add(:addresses, class: 'btn btn-success', data: { target: "#addresses" }) do  %>
+      <%= link_to_add_association(form, :addresses,
+                                  { "data-association-insertion-node": "#addresses",
+                                    "data-association-insertion-method": 'append'}) do  %>
         <i class='glyphicon glyphicon-plus-sign'></i>Add Address 
       <% end %> 
     </span>
   </div>
   <div class="panel-body" id="addresses">
       <%= form.fields_for :addresses do |addr| %>
-        <%= addr.select :address_type, Address.address_types.map(&:first) %>
-        <%= addr.text_field :street_address_1 %>
-        <%= addr.text_field :street_address_2 %>
-        <%= addr.text_field :city %>
-        <%= addr.text_field :state %>
-        <%= addr.text_field :postal_code %>
-        <%= addr.text_field :country %>
+        <%= render 'address_fields', f: addr %>
       <% end %>
   </div>
 </div>
@@ -36,20 +36,16 @@
 <div class='panel panel-default'>
   <div class="panel-heading"><span>Other Information</span></div>
   <div class="panel-body" id="other-info">
-    <%= form.label :has_family_member do %>
-      <span class='radio-question' >Do you have a family member that works at UMD Libraries?</span> 
-      <%= form.radio_button :has_family_member, false, checked: true, value: false, label: "No",  data: { toggle: "collapse", target: "#collapseFamilyMember" }, inline: true  %>        
-      <%= form.radio_button :has_family_member, true, value: true, label: "Yes",  data: { toggle: "collapse", target: "#collapseFamilyMember" }, inline: true %>        
-    <% end %>
+    <%= form.input :has_family_member, as: :radio_buttons, collection: [["No", false], ["Yes", true]], 
+      label: "Do you have a family member that works at UMD Libraries?", input_html: { data: { toggle: "collapse",
+        target: "#collapseFamilyMember" } }   %> 
     <div id="collapseFamilyMember" class="collapse">
-        <div class="panel-body"><%= form.text_field :family_member %></div>
+        <div class="panel-body"><%= form.input :family_member, required: true %></div>
     </div>
     <br/>  
-    <%= form.label :in_work_study do %>
-      <span class='radio-question' >Are you in a Federal Work Study program?</span> 
-      <%= form.radio_button :in_federal_study, false, checked: true, value: false, label: "No", inline: true  %>        
-      <%= form.radio_button :in_federal_study, true, value: true, label: "Yes", inline: true %>        
-    <% end %>
+    <%= form.input :in_federal_study, as: :radio_buttons, collection: [["No", false], ["Yes", true]], 
+      label: "Are you in a Federal Work Study program?" %>
+        
            
   </div>
 </div>

--- a/app/views/prospects/_skills_step.html.erb
+++ b/app/views/prospects/_skills_step.html.erb
@@ -1,4 +1,4 @@
 <h2>Skills</h2>
 
-<%= form.collection_select :skill_ids, Skill.all, :id, :name, {},
-  { multiple: true, class: 'select2' } %>
+<%= form.input :skills_ids, collection: Skill.all.map { |s| [ s.name, s.id ] }, 
+  as: :select, input_html: { multiple: true } %>

--- a/app/views/prospects/_work_experience_fields.html.erb
+++ b/app/views/prospects/_work_experience_fields.html.erb
@@ -1,0 +1,11 @@
+<div class='address nested-fields'>
+  <%= link_to_remove_association "remove", f, { class: 'pull-right' } %>
+  <%= f.input :name %>
+  <%= f.input :dates_of_employment %>
+  <%= f.input :location %>
+  <%= f.input :duties %>
+  <%= f.label :library_related do %>
+    <%= f.input :library_related, as: :radio_buttons, collection: [["No", false], ["Yes", true]], 
+      label: "Is this position library related?"  %> 
+  <% end %>
+</div>

--- a/app/views/prospects/_work_experience_step.html.erb
+++ b/app/views/prospects/_work_experience_step.html.erb
@@ -1,24 +1,18 @@
 <h2>Work Experience</h2>
 
 <div class='panel panel-default'>
-  <div class="panel-heading"><span>Work Experiences</span>
+  <div class="panel-heading"><span></span>
     <span class='pull-right'>
-      <%= form.link_to_add(:work_experiences, class: 'btn btn-success', data: { target: "#work-experiences" }) do  %>
-        <i class='glyphicon glyphicon-plus-sign'></i>Add Work Experiences 
+      <%= link_to_add_association(form, :work_experiences,
+                                  { "data-association-insertion-node": "#work-experiences",
+                                    "data-association-insertion-method": 'append'}) do  %>
+        <i class='glyphicon glyphicon-plus-sign'></i>Add Work Experience 
       <% end %> 
     </span>
   </div>
   <div class="panel-body" id="work-experiences">
-      <%= form.fields_for :work_experiences do |we| %>
-        <%= we.text_field :name %>
-        <%= we.text_field :dates_of_employment %>
-        <%= we.text_field :location %>
-        <%= we.text_area :duties %>
-        <%= we.label :library_related do %>
-          <span class='radio-question' >Is this position library related?</span> 
-          <%= we.radio_button :library_related, false, checked: true, value: false, label: "No", inline: true  %>        
-          <%= we.radio_button :library_related, true, value: true, label: "Yes", inline: true %>        
-        <% end %>
+      <%= form.fields_for :work_experiences do |ws| %>
+        <%= render 'work_experience_fields', f: ws %>
       <% end %>
   </div>
 </div>

--- a/app/views/prospects/new.html.erb
+++ b/app/views/prospects/new.html.erb
@@ -2,7 +2,14 @@
   <h1>New Student Application</h1>
 </div>
 
-<%= bootstrap_nested_form_for @prospect, layout: :horizontal do |form| %>
+<%= simple_form_for @prospect,  html: { class: 'form-horizontal' },
+  wrapper_mappings: {
+    check_boxes: :horizontal_radio_and_checkboxes,
+    radio_buttons: :horizontal_radio_and_checkboxes,
+    file: :horizontal_file_input,
+    boolean: :horizontal_boolean
+  } do |form| %>
+  <%= form.error_notification %> 
   <%= render "#{@prospect.current_step}_step", form: form %>
   <p><%= form.submit @prospect.last_step? ? "Submit" : "Continue", class: @prospect.last_step? ? 'btn btn-success' : 'btn btn-default' %></p>
   <p><%= form.submit "Back", name: "back_button" unless @prospect.first_step? %></p>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,0 +1,165 @@
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Wrappers are used by the form builder to generate a
+  # complete input. You can remove any component from the
+  # wrapper, change the order or even add your own to the
+  # stack. The options given below are used to wrap the
+  # whole input.
+  config.wrappers :default, class: :input,
+    hint_class: :field_with_hint, error_class: :field_with_errors do |b|
+    ## Extensions enabled by default
+    # Any of these extensions can be disabled for a
+    # given input by passing: `f.input EXTENSION_NAME => false`.
+    # You can make any of these extensions optional by
+    # renaming `b.use` to `b.optional`.
+
+    # Determines whether to use HTML5 (:email, :url, ...)
+    # and required attributes
+    b.use :html5
+
+    # Calculates placeholders automatically from I18n
+    # You can also pass a string as f.input placeholder: "Placeholder"
+    b.use :placeholder
+
+    ## Optional extensions
+    # They are disabled unless you pass `f.input EXTENSION_NAME => true`
+    # to the input. If so, they will retrieve the values from the model
+    # if any exists. If you want to enable any of those
+    # extensions by default, you can change `b.optional` to `b.use`.
+
+    # Calculates maxlength from length validations for string inputs
+    b.optional :maxlength
+
+    # Calculates pattern from format validations for string inputs
+    b.optional :pattern
+
+    # Calculates min and max from length validations for numeric inputs
+    b.optional :min_max
+
+    # Calculates readonly automatically from readonly attributes
+    b.optional :readonly
+
+    ## Inputs
+    b.use :label_input
+    b.use :hint,  wrap_with: { tag: :span, class: :hint }
+    b.use :error, wrap_with: { tag: :span, class: :error }
+
+    ## full_messages_for
+    # If you want to display the full error message for the attribute, you can
+    # use the component :full_error, like:
+    #
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :nested
+
+  # Default class for buttons
+  config.button_class = 'btn'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  # config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'error_notification'
+
+  # ID to add for error notification helper.
+  # config.error_notification_id = nil
+
+  # Series of attempts to detect a default label method for collection.
+  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
+
+  # Series of attempts to detect a default value method for collection.
+  # config.collection_value_methods = [ :id, :to_s ]
+
+  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
+  # config.collection_wrapper_tag = nil
+
+  # You can define the class to use on all collection wrappers. Defaulting to none.
+  # config.collection_wrapper_class = nil
+
+  # You can wrap each item in a collection of radio/check boxes with a tag,
+  # defaulting to :span.
+  # config.item_wrapper_tag = :span
+
+  # You can define a class to use in all item wrappers. Defaulting to none.
+  # config.item_wrapper_class = nil
+
+  # How the label text should be generated altogether with the required text.
+  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+
+  # You can define the class to use on all labels. Default is nil.
+  # config.label_class = nil
+
+  # You can define the default class to be used on forms. Can be overriden
+  # with `html: { :class }`. Defaulting to none.
+  # config.default_form_class = nil
+
+  # You can define which elements should obtain additional classes
+  # config.generate_additional_classes_for = [:wrapper, :label, :input]
+
+  # Whether attributes are required by default (or not). Default is true.
+  # config.required_by_default = true
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Collection of methods to detect if a file type was given.
+  # config.file_methods = [ :mounted_as, :file?, :public_filename ]
+
+  # Custom mappings for input types. This should be a hash containing a regexp
+  # to match as key, and the input type that will be used when the field name
+  # matches the regexp as value.
+  # config.input_mappings = { /count/ => :integer }
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  # config.wrapper_mappings = { string: :prepend }
+
+  # Namespaces where SimpleForm should look for custom input classes that
+  # override default inputs.
+  # config.custom_inputs_namespaces << "CustomInputs"
+
+  # Default priority for time_zone inputs.
+  # config.time_zone_priority = nil
+
+  # Default priority for country inputs.
+  # config.country_priority = nil
+
+  # When false, do not use translations for labels.
+  # config.translate_labels = true
+
+  # Automatically discover new inputs in Rails' autoload path.
+  # config.inputs_discovery = true
+
+  # Cache SimpleForm inputs discovery
+  # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = nil
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
+
+  # Defines which i18n scope will be used in Simple Form.
+  # config.i18n_scope = 'simple_form'
+end

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -6,7 +6,7 @@ SimpleForm.setup do |config|
   # stack. The options given below are used to wrap the
   # whole input.
   config.wrappers :default, class: :input,
-    hint_class: :field_with_hint, error_class: :field_with_errors do |b|
+                            hint_class: :field_with_hint, error_class: :field_with_errors do |b|
     ## Extensions enabled by default
     # Any of these extensions can be disabled for a
     # given input by passing: `f.input EXTENSION_NAME => false`.

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -1,0 +1,149 @@
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  config.error_notification_class = 'alert alert-danger'
+  config.button_class = 'btn btn-default'
+  config.boolean_label_class = nil
+
+  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'control-label'
+
+    b.use :input, class: 'form-control'
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :vertical_file_input, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :readonly
+    b.use :label, class: 'control-label'
+
+    b.use :input
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :vertical_boolean, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+
+    b.wrapper tag: 'div', class: 'checkbox' do |ba|
+      ba.use :label_input
+    end
+
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :vertical_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'control-label'
+    b.use :input
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :horizontal_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 control-label'
+
+    b.wrapper tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-control'
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
+  config.wrappers :horizontal_file_input, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 control-label'
+
+    b.wrapper tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
+  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+
+    b.wrapper tag: 'div', class: 'col-sm-offset-3 col-sm-9' do |wr|
+      wr.wrapper tag: 'div', class: 'checkbox' do |ba|
+        ba.use :label_input
+      end
+
+      wr.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      wr.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
+  config.wrappers :horizontal_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+
+    b.use :label, class: 'col-sm-3 control-label'
+
+    b.wrapper tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
+  config.wrappers :inline_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'sr-only'
+
+    b.use :input, class: 'form-control'
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+
+  config.wrappers :multi_select, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'control-label'
+    b.wrapper tag: 'div', class: 'form-inline' do |ba|
+      ba.use :input, class: 'form-control'
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+  # Wrappers for forms and inputs using the Bootstrap toolkit.
+  # Check the Bootstrap docs (http://getbootstrap.com)
+  # to learn about the different styles for forms and inputs,
+  # buttons and other elements.
+  config.default_wrapper = :vertical_form
+  config.wrapper_mappings = {
+    check_boxes: :vertical_radio_and_checkboxes,
+    radio_buttons: :vertical_radio_and_checkboxes,
+    file: :vertical_file_input,
+    boolean: :vertical_boolean,
+    datetime: :multi_select,
+    date: :multi_select,
+    time: :multi_select
+  }
+end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,31 @@
+en:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/db/migrate/20161024210928_available_times_redo.rb
+++ b/db/migrate/20161024210928_available_times_redo.rb
@@ -1,0 +1,14 @@
+class AvailableTimesRedo < ActiveRecord::Migration
+  def change
+    
+    add_column :available_times, :day, :integer, default: 0, null: false
+    add_column :available_times, :time, :integer, default: 0, null: false
+    
+    remove_column :available_times, :available_day_id
+    remove_column :available_times,  :start
+    remove_column :available_times,  :end
+    remove_column :available_times, :all_day
+   
+    drop_table :available_days
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161021173906) do
+ActiveRecord::Schema.define(version: 20161024210928) do
 
   create_table "addresses", force: :cascade do |t|
     t.string  "street_address_1"
@@ -26,18 +26,10 @@ ActiveRecord::Schema.define(version: 20161021173906) do
 
   add_index "addresses", ["prospect_id"], name: "index_addresses_on_prospect_id"
 
-  create_table "available_days", force: :cascade do |t|
-    t.integer "day",               default: 0, null: false
-    t.integer "available_time_id"
-  end
-
-  add_index "available_days", ["available_time_id"], name: "index_available_days_on_available_time_id"
-
   create_table "available_times", force: :cascade do |t|
-    t.datetime "start"
-    t.datetime "end"
-    t.boolean  "all_day",     default: false, null: false
-    t.integer  "prospect_id"
+    t.integer "prospect_id"
+    t.integer "day",         default: 0, null: false
+    t.integer "time",        default: 0, null: false
   end
 
   add_index "available_times", ["prospect_id"], name: "index_available_times_on_prospect_id"

--- a/lib/templates/erb/scaffold/_form.html.erb
+++ b/lib/templates/erb/scaffold/_form.html.erb
@@ -1,0 +1,13 @@
+<%%= simple_form_for(@<%= singular_table_name %>) do |f| %>
+  <%%= f.error_notification %>
+
+  <div class="form-inputs">
+  <%- attributes.each do |attribute| -%>
+    <%%= f.<%= attribute.reference? ? :association : :input %> :<%= attribute.name %> %>
+  <%- end -%>
+  </div>
+
+  <div class="form-actions">
+    <%%= f.button :submit %>
+  </div>
+<%% end %>

--- a/test/features/availability_test.rb
+++ b/test/features/availability_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+feature 'Add some Available Times' do
+  scenario 'add some availability to the prospect', js: true do
+    # we can fast-forward to the available_times step
+    all_valid = prospects(:all_valid).attributes
+    page.set_rack_session("prospect_params": all_valid)
+
+    visit root_path
+    click_link 'Apply!'
+
+    click_button 'Continue' until page.has_content?('Availability')
+    # lets get 5 random date_times
+    day_times = [*0..4].map do
+      [*0..6].sample
+    end.inject([]) do |c, v|
+      val = "#{v}-#{[*0..23].sample}"
+      redo if c.include?(val)
+      c << val
+    end
+    # lets click the 5 tds related to that checkbox
+    day_times.each do |dt|
+      find(:css, "input[value='#{dt}']", visible: false).first(:xpath, './/../..').click
+    end
+
+    assert_equal 5, find_all(:css, 'input[type=checkbox]:checked', visible: false).length
+    assert_equal 5, find_all(:css, 'td.success').length
+
+    # we do a little dance...
+    click_button 'Continue'
+    click_button 'Back'
+
+    assert_equal 5, find_all(:css, 'input[type=checkbox]:checked', visible: false).length
+    assert_equal 5, find_all(:css, 'td.success').length
+  end
+end

--- a/test/features/contact_information_test.rb
+++ b/test/features/contact_information_test.rb
@@ -69,11 +69,11 @@ feature 'Enter contact information' do
 
     # lets add five new addresses
     5.times do |i|
-      assert_equal i + 1, find(:css, '#addresses').all('.fields').length
-
-      within("#addresses .fields:nth-child(#{i + 1})") do
-        %w(_street_address_1 _city _state _postal_code).each do |attr|
-          el_id = find("input[id$='#{attr}']")[:id]
+      assert_equal i + 1,find(:css, "#addresses").all(".nested-fields").length
+      
+      within("#addresses .nested-fields:nth-child(#{i + 1})") do
+        %w( _street_address_1 _city _state _postal_code  ).each do |attr|
+          el_id =  find("input[id$='#{attr}']")[:id]
           fill_in(el_id, with: "#{attr} #{i} ")
         end
       end
@@ -85,13 +85,13 @@ feature 'Enter contact information' do
     click_button 'Continue'
     click_button 'Back'
 
-    assert_equal 5, find(:css, '#addresses').all('.fields').length
+    assert_equal 5, find(:css, '#addresses').all('.nested-fields').length
 
     # and with all our content
     5.times do |i|
-      within("#addresses .fields:nth-child(#{i + 1})") do
-        %w(_street_address_1 _city _state _postal_code).each_with_index do |attr|
-          el_id = find("input[id$='#{attr}']")[:id]
+      within("#addresses .nested-fields:nth-child(#{i + 1})") do
+        %w( _street_address_1 _city _state _postal_code  ).each_with_index do |attr|
+          el_id =  find("input[id$='#{attr}']")[:id]
           assert page.has_field?(el_id, with: "#{attr} #{i} ")
         end
       end

--- a/test/features/contact_information_test.rb
+++ b/test/features/contact_information_test.rb
@@ -39,23 +39,26 @@ feature 'Enter contact information' do
     fill_in('prospect_addresses_attributes_0_state', with: 'AK')
     fill_in('prospect_addresses_attributes_0_postal_code', with: '12345')
 
-    refute page.has_field?('prospect_family_member', visible: true)
-    find('#prospect_has_family_member_true').click
-    assert page.has_field?('prospect_family_member', visible: true, with: '')
+    refute page.has_css?('#prospect_family_member', visible: true)
+    find(:css, '#prospect_has_family_member_true').click
+    sleep 1
+    assert page.has_css?('#prospect_family_member', visible: true)
 
     fill_in('prospect_family_member', with: 'Lebron James')
     click_button 'Continue'
     click_button 'Back'
 
     # we should still have the member name
-    assert page.has_field?('prospect_family_member', visible: true, with: 'Lebron James')
+    assert page.has_css?('#prospect_family_member', visible: true)
+    assert page.has_field?('prospect_family_member', with: 'Lebron James')
 
     # now click false and it should disapear and be erased
     find('#prospect_has_family_member_false').click
-    refute page.has_field?('prospect_family_member', visible: true, with: 'Lebron James')
+    refute page.has_field?('prospect_family_member', with: 'Lebron James')
     # reopen
     find('#prospect_has_family_member_true').click
-    assert page.has_field?('prospect_family_member', visible: true, with: '')
+    assert page.has_css?('#prospect_family_member', visible: true)
+    assert page.has_field?('prospect_family_member', with: '')
   end
 
   scenario 'user wants to add multiple addresses in the contact_information page', js: true do
@@ -69,11 +72,11 @@ feature 'Enter contact information' do
 
     # lets add five new addresses
     5.times do |i|
-      assert_equal i + 1,find(:css, "#addresses").all(".nested-fields").length
-      
+      assert_equal i + 1, find(:css, '#addresses').all('.nested-fields').length
+
       within("#addresses .nested-fields:nth-child(#{i + 1})") do
-        %w( _street_address_1 _city _state _postal_code  ).each do |attr|
-          el_id =  find("input[id$='#{attr}']")[:id]
+        %w(_street_address_1 _city _state _postal_code).each do |attr|
+          el_id = find("input[id$='#{attr}']")[:id]
           fill_in(el_id, with: "#{attr} #{i} ")
         end
       end
@@ -90,8 +93,8 @@ feature 'Enter contact information' do
     # and with all our content
     5.times do |i|
       within("#addresses .nested-fields:nth-child(#{i + 1})") do
-        %w( _street_address_1 _city _state _postal_code  ).each_with_index do |attr|
-          el_id =  find("input[id$='#{attr}']")[:id]
+        %w(_street_address_1 _city _state _postal_code).each_with_index do |attr|
+          el_id = find("input[id$='#{attr}']")[:id]
           assert page.has_field?(el_id, with: "#{attr} #{i} ")
         end
       end

--- a/test/features/end_to_end_test.rb
+++ b/test/features/end_to_end_test.rb
@@ -17,45 +17,43 @@ feature 'submit an application' do
     fill_in('prospect_addresses_attributes_0_city', with: 'Springfield')
     fill_in('prospect_addresses_attributes_0_state', with: 'HI')
     fill_in('prospect_addresses_attributes_0_postal_code', with: '12345')
-    
+
     find('#prospect_has_family_member_true').click
     assert page.has_field?('prospect_family_member', visible: true, with: '')
 
     fill_in('prospect_family_member', with: 'Steve Blake')
-    
+
     find('#prospect_in_federal_study_true').click
 
     click_button 'Continue'
     assert page.has_content?('Work Experience')
-    
-    click_link "Add Work Experience"
-    assert_equal 1,find(:css, "#work-experiences").all(".nested-fields").length
-    
-    within("#work-experiences .nested-fields:nth-child(1)") do
-      %w( _name _dates_of_employment _location    ).each do |attr|
-          el_id =  find("input[id$='#{attr}']")[:id]
-          fill_in( el_id, with: attr ) 
-      end 
-      %w( _duties ).each do |attr|
-          el_id =  find("textarea[id$='#{attr}']")[:id]
-          fill_in( el_id, with: attr ) 
+
+    click_link 'Add Work Experience'
+    assert_equal 1, find(:css, '#work-experiences').all('.nested-fields').length
+
+    within('#work-experiences .nested-fields:nth-child(1)') do
+      %w(_name _dates_of_employment _location).each do |attr|
+        el_id = find("input[id$='#{attr}']")[:id]
+        fill_in(el_id, with: attr)
+      end
+      %w(_duties).each do |attr|
+        el_id = find("textarea[id$='#{attr}']")[:id]
+        fill_in(el_id, with: attr)
       end
     end
 
-    click_button "Continue"
-    
+    click_button 'Continue'
+
     assert page.has_content?('Skills')
-    # to do add skills test 
-    
-    click_button "Continue"
+    # to do add skills test
+
+    click_button 'Continue'
     assert page.has_content?('Availability')
-    # to do add availability test 
-    click_button "Continue"
+    # to do add availability test
+    click_button 'Continue'
     assert page.has_content?('Confirmation')
-    # to do add confirmation test 
-    click_button "Submit"
+    # to do add confirmation test
+    click_button 'Submit'
     assert page.has_content?('Saved')
-
   end
-
 end

--- a/test/features/end_to_end_test.rb
+++ b/test/features/end_to_end_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+# rubocop:disable Metrics/BlockLength
+feature 'submit an application' do
+  scenario 'just submit a standard application from start to finish', js: true do
+    # pretty boring test, since it's the exact same as out integration
+    # test..just to get the ball rollin'
+    visit root_path
+    click_link 'Apply!'
+
+    fill_in('Directory', with: 'myIdentifier')
+    fill_in('prospect_first_name', with: 'Polly')
+    fill_in('prospect_last_name', with: 'Jane')
+    fill_in('prospect_email', with: 'pj@umd.edu')
+
+    fill_in('prospect_addresses_attributes_0_street_address_1', with: '555 Fake St')
+    fill_in('prospect_addresses_attributes_0_city', with: 'Springfield')
+    fill_in('prospect_addresses_attributes_0_state', with: 'HI')
+    fill_in('prospect_addresses_attributes_0_postal_code', with: '12345')
+    
+    find('#prospect_has_family_member_true').click
+    assert page.has_field?('prospect_family_member', visible: true, with: '')
+
+    fill_in('prospect_family_member', with: 'Steve Blake')
+    
+    find('#prospect_in_federal_study_true').click
+
+    click_button 'Continue'
+    assert page.has_content?('Work Experience')
+    
+    click_link "Add Work Experience"
+    assert_equal 1,find(:css, "#work-experiences").all(".nested-fields").length
+    
+    within("#work-experiences .nested-fields:nth-child(1)") do
+      %w( _name _dates_of_employment _location    ).each do |attr|
+          el_id =  find("input[id$='#{attr}']")[:id]
+          fill_in( el_id, with: attr ) 
+      end 
+      %w( _duties ).each do |attr|
+          el_id =  find("textarea[id$='#{attr}']")[:id]
+          fill_in( el_id, with: attr ) 
+      end
+    end
+
+    click_button "Continue"
+    
+    assert page.has_content?('Skills')
+    # to do add skills test 
+    
+    click_button "Continue"
+    assert page.has_content?('Availability')
+    # to do add availability test 
+    click_button "Continue"
+    assert page.has_content?('Confirmation')
+    # to do add confirmation test 
+    click_button "Submit"
+    assert page.has_content?('Saved')
+
+  end
+
+end

--- a/test/features/work_experiences_test.rb
+++ b/test/features/work_experiences_test.rb
@@ -9,12 +9,12 @@ feature "Add some work experiences" do
     
     visit root_path
     click_link "Apply!" 
-    assert page.has_content?("Work Experiences") 
+    assert page.has_content?("Work Experience") 
     
-    click_link "Add Work Experiences"
-    assert_equal 1,find(:css, "#work-experiences").all(".fields").length
+    click_link "Add Work Experience"
+    assert_equal 1,find(:css, "#work-experiences").all(".nested-fields").length
     
-    within("#work-experiences .fields:nth-child(1)") do
+    within("#work-experiences .nested-fields:nth-child(1)") do
       %w( _name _dates_of_employment _location    ).each do |attr|
           el_id =  find("input[id$='#{attr}']")[:id]
           fill_in( el_id, with: attr ) 
@@ -26,20 +26,20 @@ feature "Add some work experiences" do
     end
 
     # we do a little dance...
-    click_link "Add Work Experiences"
-    assert_equal 2,find(:css, "#work-experiences").all(".fields").length
+    click_link "Add Work Experience"
+    assert_equal 2,find(:css, "#work-experiences").all(".nested-fields").length
     
     click_button "Continue"
     click_button "Back" 
     
-    assert_equal 2,find(:css, "#work-experiences").all(".fields").length
+    assert_equal 2,find(:css, "#work-experiences").all(".nested-fields").length
      
     click_button "Back" 
     click_button "Continue"
-    assert_equal 2,find(:css, "#work-experiences").all(".fields").length
+    assert_equal 2,find(:css, "#work-experiences").all(".nested-fields").length
 
     # ... and values are still in place
-    within("#work-experiences .fields:nth-child(1)") do
+    within("#work-experiences .nested-fields:nth-child(1)") do
       %w( _name _dates_of_employment _location  ).each_with_index do |attr|
           el_id =  find("input[id$='#{attr}']")[:id]
           assert page.has_field?( el_id, with: attr ) 

--- a/test/features/work_experiences_test.rb
+++ b/test/features/work_experiences_test.rb
@@ -1,54 +1,53 @@
 require 'test_helper'
 
-feature "Add some work experiences" do
-  scenario "add some experiences to the prospect", js: true do
+feature 'Add some work experiences' do
+  scenario 'add some experiences to the prospect', js: true do
     # we can fast-forward to the work_experiences step
-    all_valid = prospects(:all_valid).attributes 
-    page.set_rack_session( "prospect_params": all_valid )
-    page.set_rack_session( "prospect_step": "work_experience")
-    
+    all_valid = prospects(:all_valid).attributes
+    page.set_rack_session("prospect_params": all_valid)
+    page.set_rack_session("prospect_step": 'work_experience')
+
     visit root_path
-    click_link "Apply!" 
-    assert page.has_content?("Work Experience") 
-    
-    click_link "Add Work Experience"
-    assert_equal 1,find(:css, "#work-experiences").all(".nested-fields").length
-    
-    within("#work-experiences .nested-fields:nth-child(1)") do
-      %w( _name _dates_of_employment _location    ).each do |attr|
-          el_id =  find("input[id$='#{attr}']")[:id]
-          fill_in( el_id, with: attr ) 
-      end 
-      %w( _duties ).each do |attr|
-          el_id =  find("textarea[id$='#{attr}']")[:id]
-          fill_in( el_id, with: attr ) 
+    click_link 'Apply!'
+    assert page.has_content?('Work Experience')
+
+    click_link 'Add Work Experience'
+    assert_equal 1, find(:css, '#work-experiences').all('.nested-fields').length
+
+    within('#work-experiences .nested-fields:nth-child(1)') do
+      %w(_name _dates_of_employment _location).each do |attr|
+        el_id = find("input[id$='#{attr}']")[:id]
+        fill_in(el_id, with: attr)
+      end
+      %w(_duties).each do |attr|
+        el_id = find("textarea[id$='#{attr}']")[:id]
+        fill_in(el_id, with: attr)
       end
     end
 
     # we do a little dance...
-    click_link "Add Work Experience"
-    assert_equal 2,find(:css, "#work-experiences").all(".nested-fields").length
-    
-    click_button "Continue"
-    click_button "Back" 
-    
-    assert_equal 2,find(:css, "#work-experiences").all(".nested-fields").length
-     
-    click_button "Back" 
-    click_button "Continue"
-    assert_equal 2,find(:css, "#work-experiences").all(".nested-fields").length
+    click_link 'Add Work Experience'
+    assert_equal 2, find(:css, '#work-experiences').all('.nested-fields').length
+
+    click_button 'Continue'
+    click_button 'Back'
+
+    assert_equal 2, find(:css, '#work-experiences').all('.nested-fields').length
+
+    click_button 'Back'
+    click_button 'Continue'
+    assert_equal 2, find(:css, '#work-experiences').all('.nested-fields').length
 
     # ... and values are still in place
-    within("#work-experiences .nested-fields:nth-child(1)") do
-      %w( _name _dates_of_employment _location  ).each_with_index do |attr|
-          el_id =  find("input[id$='#{attr}']")[:id]
-          assert page.has_field?( el_id, with: attr ) 
+    within('#work-experiences .nested-fields:nth-child(1)') do
+      %w(_name _dates_of_employment _location).each_with_index do |attr|
+        el_id = find("input[id$='#{attr}']")[:id]
+        assert page.has_field?(el_id, with: attr)
       end
-      %w( _duties ).each do |attr|
-          el_id =  find("textarea[id$='#{attr}']")[:id]
-          assert page.has_field?( el_id, with: attr ) 
+      %w(_duties).each do |attr|
+        el_id = find("textarea[id$='#{attr}']")[:id]
+        assert page.has_field?(el_id, with: attr)
       end
     end
-
   end
 end

--- a/test/fixtures/addresses.yml
+++ b/test/fixtures/addresses.yml
@@ -8,6 +8,7 @@ contact_info_gotham:
 all_valid_springfield:
   prospect: all_valid 
   street_address_1: 555 Fake. St
+  street_address_2: 555 Fake. St
   city: Springfield
   state: IL
   postal_code: 12345

--- a/test/models/available_day_test.rb
+++ b/test/models/available_day_test.rb
@@ -7,17 +7,11 @@ class AvailableTimeTest < ActiveSupport::TestCase
   end
 
   test 'it should allow to create new available times with days passed in' do
-    at = AvailableTime.new days: 'monday'
-    assert_includes at.days, 'monday'
+    at = AvailableTime.new day: 'monday', time: 0
+    assert_equal at.day_time, "1-0"
     at.save
-    assert_includes at.days, 'monday'
-    assert_includes at.available_days.map(&:day), 'monday'
+    at.day = "sunday" 
+    assert_equal at.day_time, "0-0"
   end
 
-  test "it should allow for adding days from a init'ed object" do
-    at = AvailableTime.new
-    at.days = %w(thursday sunday)
-    assert_includes at.available_days.map(&:day), 'thursday'
-    assert_includes at.days, 'sunday'
-  end
 end

--- a/test/models/available_day_test.rb
+++ b/test/models/available_day_test.rb
@@ -8,10 +8,9 @@ class AvailableTimeTest < ActiveSupport::TestCase
 
   test 'it should allow to create new available times with days passed in' do
     at = AvailableTime.new day: 'monday', time: 0
-    assert_equal at.day_time, "1-0"
+    assert_equal at.day_time, '1-0'
     at.save
-    at.day = "sunday" 
-    assert_equal at.day_time, "0-0"
+    at.day = 'sunday'
+    assert_equal at.day_time, '0-0'
   end
-
 end

--- a/test/models/prospect_test.rb
+++ b/test/models/prospect_test.rb
@@ -82,4 +82,14 @@ class ProspectTest < ActiveSupport::TestCase
     end
     assert homeless.valid?
   end
+
+  test "it should be able to create available_times via the day_times shortcut" do
+    prospect = Prospect.new day_times: [ "0-0", "4-20", "0-12" ]
+    assert_equal prospect.available_times.length, prospect.day_times.length 
+    prospect.available_times.each do |a|
+      assert_includes prospect.day_times, a.day_time
+    end
+
+  end
+
 end

--- a/test/models/prospect_test.rb
+++ b/test/models/prospect_test.rb
@@ -83,13 +83,11 @@ class ProspectTest < ActiveSupport::TestCase
     assert homeless.valid?
   end
 
-  test "it should be able to create available_times via the day_times shortcut" do
-    prospect = Prospect.new day_times: [ "0-0", "4-20", "0-12" ]
-    assert_equal prospect.available_times.length, prospect.day_times.length 
+  test 'it should be able to create available_times via the day_times shortcut' do
+    prospect = Prospect.new day_times: ['0-0', '4-20', '0-12']
+    assert_equal prospect.available_times.length, prospect.day_times.length
     prospect.available_times.each do |a|
       assert_includes prospect.day_times, a.day_time
     end
-
   end
-
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,8 +21,15 @@ Minitest::Reporters.use!(
 require 'capybara/rails'
 require 'capybara/poltergeist'
 require 'capybara-screenshot/minitest'
-Capybara.javascript_driver = :poltergeist
 
+# for debugging
+# https://github.com/teampoltergeist/poltergeist#remote-debugging-experimental
+# Capybara.register_driver :poltergeist_debug do |app|
+#  Capybara::Poltergeist::Driver.new(app, :inspector => true)
+# end
+# Capybara.javascript_driver = :poltergeist_debug
+
+Capybara.javascript_driver = :poltergeist
 require 'rack_session_access/capybara'
 
 Capybara::Screenshot.after_save_html do |path|


### PR DESCRIPTION
This makes the availability_times selection step UI a table of days
and hours which users can select from. The db schema is changed to keep
available times in a single table, with day and start hour recorded ( we are
assuming hour long chunks  )

This also removed the nested_form gem and adds the simple_form and cocoon gems (
which nested_form was using under the hood ). This hopefully simplifies the form
helper fun.

https://issues.umd.edu/browse/LIBITD-568