### PR TITLE
LIBITD-668 Allow Admins to impersonate supervisors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,6 +40,7 @@ class ApplicationController < ActionController::Base
     attr_writer :current_user
     def update_current_user(user)
       @current_user = user
+      @current_user.admin = false if session[:disable_admin]
       @current_user
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :ensure_auth
-  before_action :ensure_admin
+  before_action :ensure_admin, except: :disable_admin
 
   def create
     @user = User.new(user_params)
@@ -33,6 +33,13 @@ class UsersController < ApplicationController
     respond_to do |format|
       format.html { redirect_to users_url, notice: "#{@user.name} deleted." }
       format.json { head :no_content }
+    end
+  end
+
+  def disable_admin
+    session[:disable_admin] = true
+    respond_to do |format|
+      format.html { redirect_to prospects_url, notice: 'You have temporarly disabled admin functionality. Sign out and log back in to restore admin role.' }
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
   <ul class="nav navbar-nav">
     <li>
       <% if !session[:prospect_params] %> 
-        <%= link_to(  prospects_path ) do  %>
+        <%= link_to(  prospects_path, id: 'user-sign-in' ) do  %>
           <%= login_label %>
         <% end %>
       <% else %>  

--- a/app/views/prospects/index.html.erb
+++ b/app/views/prospects/index.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-striped">
+<table class="table table-striped prospects">
   <thead>
     <% if  @current_user.admin? %> 
       <tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,3 +1,14 @@
+<% if @current_user.admin? %>
+<div id="admin_container" class="container" >
+  <div class="well text-center">
+    <h4>You are an admin user and you will see fields slightly different that other logged in users.</h4>
+    <h5>If you would like to temporarly switch this off, please click the link below:</h5> 
+      <%= link_to "Disable Admin", disable_admin_url, class: "btn btn-warning" %> 
+  </div>
+
+</div>
+<% end %>
+
 <div id="users_container" class="container" >
   <table class="table table-strpied">
     <thead>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get 'logout' => 'home#sign_out', as: :logout
 
   resources :users
+  get 'disable_admin' => 'users#disable_admin', as: :disable_admin
 
   resources :prospects
   get 'prospects/:id/resume' => 'prospects#resume', as: :prospect_resume

--- a/db/seeds/demo.rb
+++ b/db/seeds/demo.rb
@@ -1,58 +1,55 @@
-require_relative "../seeds"
+require_relative '../seeds'
 
 Prospect.delete_all
 700.times do
-
   hash = {
-    directory_id: Faker::Internet.email.split("@").first,
+    directory_id: Faker::Internet.email.split('@').first,
     email: Faker::Internet.email,
     first_name: Faker::Name.first_name,
-    last_name: Faker::Name.last_name, 
-    in_federal_study: [ true, false ].sample,
+    last_name: Faker::Name.last_name,
+    in_federal_study: [true, false].sample
   }
 
   prospect = Prospect.new(hash)
   prospect.enumerations << Enumeration.active_graduation_years.sample(1)
   prospect.enumerations << Enumeration.active_class_statuses.sample(1)
-  prospect.enumerations <<  Enumeration.active_semesters.sample(1) 
-  prospect.enumerations <<  Enumeration.active_libraries.sample(3) 
+  prospect.enumerations <<  Enumeration.active_semesters.sample(1)
+  prospect.enumerations <<  Enumeration.active_libraries.sample(3)
 
   prospect.local_address.street_address_1 = Faker::Address.street_address
   prospect.local_address.city = Faker::Address.city
   prospect.local_address.postal_code = Faker::Address.postcode
 
-  if ( [true, false].sample )
-    prospect.addresses << Address.new( address_type: "permanent", street_address_1: Faker::Address.street_address,
-                   city: Faker::Address.city, postal_code: Faker::Address.postcode 
-                 )   
+  if [true, false].sample
+    prospect.addresses << Address.new(address_type: 'permanent', street_address_1: Faker::Address.street_address,
+                                      city: Faker::Address.city, postal_code: Faker::Address.postcode)
   end
-  
-  prospect.skills = Skill.promoted.sample( rand(1..Skill.promoted.count))
-  
-  [ Skill.new(name: Faker::Music.instrument), Skill.new(name: Faker::Music.instrument), Skill.new(name: Faker::Music.instrument) ].sample( rand(0..3) ).each do |s|
-    prospect.skills <<  s
+
+  prospect.skills = Skill.promoted.sample(rand(1..Skill.promoted.count))
+
+  [Skill.new(name: Faker::Music.instrument), Skill.new(name: Faker::Music.instrument), Skill.new(name: Faker::Music.instrument)].sample(rand(0..3)).each do |s|
+    prospect.skills << s
   end
 
   rand(0..3).times do
-    prospect.work_experiences << WorkExperience.new( name: Faker::Company.name, location: Faker::LordOfTheRings.location, dates_of_employment: Faker::Date.backward(rand(0..1000000)) , 
-                                            duties: Faker::Lorem.words(rand(0..10)).join("\n"), library_related: [true,false].sample )
+    prospect.work_experiences << WorkExperience.new(name: Faker::Company.name, location: Faker::LordOfTheRings.location, dates_of_employment: Faker::Date.backward(rand(0..1_000_000)),
+                                                    duties: Faker::Lorem.words(rand(0..10)).join("\n"), library_related: [true, false].sample)
   end
 
   prospect.available_hours_per_week = rand(0..40)
 
   dts = []
   rand(prospect.available_hours_per_week..168).times do
-    dts <<  "#{ rand(0..6) }-#{ rand(0..23) }"
+    dts << "#{rand(0..6)}-#{rand(0..23)}"
   end
 
   prospect.day_times = dts.uniq
   prospect.user_confirmation = true
   prospect.user_signature = Faker::Name.name
- 
-  if [true,false].sample
-    prospect.resume = Resume.new( file: File.new("test/fixtures/resume.pdf", "r") )
+
+  if [true, false].sample
+    prospect.resume = Resume.new(file: File.new('test/fixtures/resume.pdf', 'r'))
   end
 
   prospect.save
-
 end

--- a/lib/tasks/custom_seed.rake
+++ b/lib/tasks/custom_seed.rake
@@ -2,7 +2,7 @@
 namespace :db do
   namespace :seed do
     Dir[File.join(Rails.root, 'db', 'seeds', '*.rb')].each do |filename|
-      task_name = File.basename(filename, '.rb').intern    
+      task_name = File.basename(filename, '.rb').intern
       task task_name => :environment do
         load(filename) if File.exist?(filename)
       end

--- a/test/features/admin_disable_test.rb
+++ b/test/features/admin_disable_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+feature 'Should be able to login as admin and disable it temporarly' do
+  scenario 'login as admin, look around, then test the disable', js: true do
+    page.driver.resize_window(2048, 2048)
+    User.create(cas_directory_id: 'admin', name: 'admin', admin: true)
+    visit root_path
+    click_link 'Staff Sign-In'
+    fill_in 'username', with: 'admin'
+    fill_in 'password', with: 'any password'
+    click_button 'Login'
+
+    assert page.has_content?('User Management')
+    click_link 'Review Applications'
+    click_link 'User Management'
+    click_link 'Disable Admin'
+
+    assert page.has_content?('You have temporarly disabled admin functionality. Sign out and log back in to restore admin role.')
+    assert_equal 11, page.find_all('th').length
+    refute page.has_content?('User Management')
+  end
+end

--- a/test/features/reload_page_test.rb
+++ b/test/features/reload_page_test.rb
@@ -27,6 +27,7 @@ feature 'Refresh during an application should cause any problems' do
     page.evaluate_script('window.location.reload()')
     assert page.has_content?('Availability')
     click_button 'Back'
+    click_button 'Back' unless page.has_content?('Skills')
     assert page.has_content?('Skills')
 
     within('#skills .nested-fields:nth-child(1)') do


### PR DESCRIPTION
This just allows admins to turn off admin func. temporarily. Adds a link in the User
Management page that sets a disable_admin session var.

https://issues.umd.edu/browse/LIBITD-668