### PR TITLE
LIBITD-666. Make sure the correct SMTP server is being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,19 @@ $ ./bin/bundle exec guard
 Testing uses [Minitest](https://github.com/seattlerb/minitest) and [Capybara](https://github.com/jnicklas/capybara).
 [Poltergeist](https://github.com/teampoltergeist/poltergeist) provides a headless Webkit driver for Capybara, which
 can be used for Feature tests that use lots of Javascript. 
+
+## Production Environment Configuration
+
+Requires:
+
+* Postgres client to be installed (on RedHat, the "postgresql" and 
+"postgresql-devel" packages)
+
+The application uses the "dotenv" gem to configure the production environment.
+The gem expects a ".env" file in the root directory to contain the environment
+variables that are provided to Ruby. A sample "env_example" file has been
+provided to assist with this process. Simply copy the "env_example" file to
+".env" and fill out the parameters as appropriate.
+
+The configured .env file should _not_ be checked into the Git repository, as it
+contains credential information.

--- a/app/mailers/submitted_mailer.rb
+++ b/app/mailers/submitted_mailer.rb
@@ -1,7 +1,11 @@
+# Mailer for successful application submissions
 class SubmittedMailer < ApplicationMailer
   default from: 'no_reply@umd.edu'
 
   def default_email(prospect)
+    logger.info('SubmittedMailer#default_email: Mail server=' +
+                smtp_settings['address'.to_sym] +
+                ", port=#{smtp_settings['port'.to_sym]}")
     @prospect = prospect
     mail(to: @prospect.email, subject: 'We appreciate your interest in employment at UMD Libraries!')
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,14 +38,17 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Sets SMTP mailing options
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    port: 587,
-    address: 'smtp.mailgun.org',
-    domain: ENV['domain'],
-    user_name: ENV['username'],
-    password: ENV['password'],
-    authentication: :plain
-
+    address: ENV['SMTP_ADDRESS'],
+    port: ENV['SMTP_PORT'],
+    domain: ENV['SMTP_DOMAIN'],
+    user_name: ENV['SMTP_USER_NAME'],
+    password: ENV['SMTP_PASSWORD'],
+    authentication: ENV['SMTP_AUTHENTICATION'].present? ? ENV['SMTP_AUTHENTICATION'].to_sym : nil
   }
+  # Only keep non-nil values
+  config.action_mailer.smtp_settings.select! { |_k, v| v }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,14 +77,16 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  # Sets SMTP mailing options
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    port: 587,
-    address: 'smtp.mailgun.org',
-    domain: ENV['domain'],
-    user_name: ENV['username'],
-    password: ENV['password'],
-    authentication: :plain
-
+    address: ENV['SMTP_ADDRESS'],
+    port: ENV['SMTP_PORT'],
+    domain: ENV['SMTP_DOMAIN'],
+    user_name: ENV['SMTP_USER_NAME'],
+    password: ENV['SMTP_PASSWORD'],
+    authentication: ENV['SMTP_AUTHENTICATION'].present? ? ENV['SMTP_AUTHENTICATION'].to_sym : nil
   }
+  # Only keep non-nil values
+  config.action_mailer.smtp_settings.select! { |_k, v| v }
 end

--- a/env_example
+++ b/env_example
@@ -1,0 +1,46 @@
+# Example .env file
+# Make a copy of this file named ".env" and fill out the properties
+# Note: The .env file should _not_ be checked in to Git!
+
+# File containing server-specific Rails environment variables.
+# Do not check into Git!
+
+# --- config/secrets.yml
+# Secret key used to verify signed cookies - typically generated using the
+# 'rake secret' command
+SECRET_KEY_BASE=
+
+# --- config/database.yml
+# The type of database
+PROD_DATABASE_ADAPTER=postgresql
+
+# The name of the database
+PROD_DATABASE_NAME=student_applications
+
+# The encoding to use
+PROD_DATABASE_ENCODING=utf8
+
+# The username used to connect to the database
+PROD_DATABASE_USERNAME=student_applications
+
+# The password used to connect to the database
+PROD_DATABASE_PASSWORD=student_applications
+
+# The host for the database
+PROD_DATABASE_HOST=
+
+# The port for the database
+PROD_DATABASE_PORT=5432
+
+# Pool size
+PROD_DATABASE_POOL=10
+
+# --- config/environments/$RAILS_ENV.rb
+# SMTP settings for sending emails
+SMTP_ADDRESS=
+SMTP_PORT=25
+# The following are not typically used
+#SMTP_DOMAIN=
+#SMTP_USER_NAME=
+#SMTP_PASSWORD=
+#SMTP_AUTHENTICATION=


### PR DESCRIPTION
Enabled the SMTP server to be configured using the "dotenv" gem and a ".env" file.
Also added logging statement so SMTP server and port would be printed in the log file.
Added env_example file to serve as a starting point for the ".env" file.

https://issues.umd.edu/browse/LIBITD-666