### PR TITLE
LIBITD-694. Work around for incorrect MIME type in upload headers.

### DIFF
--- a/app/assets/javascripts/prospect.js
+++ b/app/assets/javascripts/prospect.js
@@ -65,12 +65,12 @@ var init = function() {
     var formData = new FormData();
 
     var file =  document.getElementById('resume_file').files[0];
-    
-    if ( !file.type.match('application/pdf')) {
+
+    if (!(/^application\/pdf$/.test(file.type) || /\.pdf$/i.test(file.name))) {
       alert("Not permitted format. Please upload a PDF.");
       return;
     }
-    
+
     formData.append("resume[file]", file, file.name);
 
 

--- a/app/controllers/resumes_controller.rb
+++ b/app/controllers/resumes_controller.rb
@@ -4,7 +4,7 @@ class ResumesController < ApplicationController
     if @resume.save
       render json: @resume.to_json
     else
-      render json: @resume.errors
+      render json: @resume.errors, status: :bad_request
     end
   end
 
@@ -15,7 +15,7 @@ class ResumesController < ApplicationController
     # if a user if logged in, they can see if.
     if @resume.prospect.nil? || logged_in?
       send_file(@resume.file.path, disposition: 'attachment', filename: @resume.file_file_name)
-    else 
+    else
       render(text: 'forbidden', status: 403, layout: false)
     end
   end
@@ -25,7 +25,7 @@ class ResumesController < ApplicationController
     if @resume.update(resume_params)
       render json: @resume.to_json
     else
-      render json: @resume.errors
+      render json: @resume.errors, status: :bad_request
     end
   end
 

--- a/app/models/resume.rb
+++ b/app/models/resume.rb
@@ -2,7 +2,20 @@
 # It includes the steps that are used to submit one
 class Resume < ActiveRecord::Base
   has_attached_file :file
-  validates_attachment_content_type :file, content_type: /\Aapplication\/pdf\z/
+
+  # fix up the MIME type using server-side detection, to overcome browsers
+  # sometimes sending incorrect Content-Type headers with PDF files
+  # adapted from http://stackoverflow.com/a/7000208/5124907
+  GENERIC_CONTENT_TYPES = ["application/force-download", "application/octet-stream"]
+
+  before_validation(:on => [:create, :update]) do |resume|
+    if GENERIC_CONTENT_TYPES.include?(resume.file_content_type)
+      mime_type = MIME::Types.type_for(resume.file_file_name)
+      resume.file_content_type = mime_type.first.content_type if mime_type.first
+    end
+  end
+
+  validates_attachment :file, content_type: { content_type: 'application/pdf' }
 
   has_one :prospect
 end


### PR DESCRIPTION
* Relax the client-side checks to be either the MIME type of application/pdf or a filename ending in ".pdf".
* Return a "400 Bad Request" status if there is a server-side error with the file upload.
* If a file comes into the server with a generic MIME type (application/octet-stream or application/force-download), do a server-side check of the MIME type before validation.

https://issues.umd.edu/browse/LIBITD-694