### PR TITLE
LIBITD-676. Removed the redundant flash_messages helper calls.

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,3 @@
-<%= flash_messages %>
-
 <div id="home-jumbo" class='jumbotron'>
   <p class='text-center'>
     <%= link_to(start_new_application_path, class: 'btn btn-lg btn-success text-center') do %>

--- a/app/views/prospects/index.html.erb
+++ b/app/views/prospects/index.html.erb
@@ -1,4 +1,3 @@
-<%= flash_messages %>
 <table class="table table-striped prospects">
   <caption>
     <% if  @current_user.admin? %> 


### PR DESCRIPTION
Since the display of flash messages are now handled by umd_lib_style, removed the flash_messages helper from the home and prospects views.

https://issues.umd.edu/browse/LIBITD-676