### PR TITLE
LIBITD-688 Restrict unsubmitted application PDF downloads to only the…

### DIFF
--- a/db/migrate/20170110065805_add_session_to_resume.rb
+++ b/db/migrate/20170110065805_add_session_to_resume.rb
@@ -1,0 +1,5 @@
+class AddSessionToResume < ActiveRecord::Migration
+  def change
+     add_column :resumes, :upload_session_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170103065805) do
+ActiveRecord::Schema.define(version: 20170110065805) do
 
   create_table "addresses", force: :cascade do |t|
     t.string  "street_address_1"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 20170103065805) do
     t.string   "file_content_type"
     t.integer  "file_file_size"
     t.datetime "file_updated_at"
+    t.string   "upload_session_id"
   end
 
   create_table "sessions", force: :cascade do |t|

--- a/test/controllers/resume_controller_test.rb
+++ b/test/controllers/resume_controller_test.rb
@@ -55,31 +55,33 @@ class ResumesControllerTest < ActionController::TestCase
     assert_response(400)
   end
 
-  test 'should allow anyone to view an unsubmitted resume' do
+  test 'should NOT allow anyone not logged in to view an unsubmitted resume' do
     resume = Resume.create(file: File.new('test/fixtures/resume.pdf', 'r'))
     get :show, id: resume.id
-    assert_response :success
+    assert_response(403)
   end
-
-  test 'should not allow anyone to view a submitted resume' do
-    prospect = prospects(:all_valid)
+  
+  test 'should not allow anyone not logged in to view a submitted resume' do
+    prospect = prospects(:all_valid) 
     prospect.build_resume( file: File.new('test/fixtures/resume.pdf', 'r'))
     prospect.save
 
     get :show, id: prospect.resume_id
     assert_response(403)
   end
-
-  test 'should allow authed users to view a submitted resume' do
-    prospect = prospects(:all_valid)
+  
+  test 'should allow authed users to view any resume' do
+    prospect = prospects(:all_valid) 
     prospect.build_resume( file: File.new('test/fixtures/resume.pdf', 'r'))
     prospect.save
 
     session[:cas] = { user: "admin" }
     get :show, id: prospect.resume_id
     assert_response :success
+    
+    resume = Resume.create(file: File.new('test/fixtures/resume.pdf', 'r'))
+    get :show, id: resume.id
+    assert_response :success
   end
-
-
 
 end

--- a/test/features/filter_available_hours_test.rb
+++ b/test/features/filter_available_hours_test.rb
@@ -27,8 +27,9 @@ feature 'Should be able filter prospects on available hours per week' do
     find(".min-slider-handle").native.drag_by(100, 0);
     find(".max-slider-handle").native.drag_by(-200, 0);
     find("#submit-filter").click
-    
+    sleep(2) 
     # But only Betty has hours in the  range 
+    
     assert page.has_content?("Student, Betty") 
     refute page.has_content?("Student, Alvin") 
     refute page.has_content?("Stone, Rolling") 

--- a/test/features/resume_upload_test.rb
+++ b/test/features/resume_upload_test.rb
@@ -4,47 +4,55 @@ require 'test_helper'
 feature 'Upload a resume' do
  
   scenario 'an application can upload a PDF', js: true do
-    # we can fast-forward to the available_times step
-   
-    digest= Digest::SHA256.file "test/fixtures/resume.pdf"
-    
-    fixture = prospects(:all_valid)
-    all_valid = fixture.attributes
-    all_valid[:enumeration_ids] = fixture.enumerations.map(&:id)
-    all_valid.reject! { |a| %w(id created_at updated_at).include? a }
+    Capybara.using_session('bad contact info') do
+      # we can fast-forward to the available_times step
+     
+      digest= Digest::SHA256.file "test/fixtures/resume.pdf"
+      
+      fixture = prospects(:all_valid)
+      all_valid = fixture.attributes
+      all_valid[:enumeration_ids] = fixture.enumerations.map(&:id)
+      all_valid.reject! { |a| %w(id created_at updated_at).include? a }
 
-    all_valid['addresses_attributes'] = [addresses(:all_valid_springfield).attributes.reject { |a| a == 'id' }]
-    all_valid['available_times_attributes'] = [available_times(:all_valid_sunday).attributes.reject { |a| a == 'id' }]
-    page.set_rack_session("prospect_params": all_valid)
+      all_valid['addresses_attributes'] = [addresses(:all_valid_springfield).attributes.reject { |a| a == 'id' }]
+      all_valid['available_times_attributes'] = [available_times(:all_valid_sunday).attributes.reject { |a| a == 'id' }]
+      page.set_rack_session("prospect_params": all_valid)
 
-    visit new_prospect_path
+      visit new_prospect_path
 
-    10.times do
+      10.times do
+        click_button 'Continue'
+        break if page.has_content?('Resume')
+      end
+     
+      assert page.has_content?('Resume')
+      page.attach_file('resume_file', 'test/fixtures/resume.pdf', visible: false) 
+     
+      find("input[name='uploadResume']").click
+      
+      assert_selector "input[value='Success!']" 
+      
       click_button 'Continue'
-      break if page.has_content?('Resume')
-    end
-    assert page.has_content?('Resume')
-    page.attach_file('resume_file', 'test/fixtures/resume.pdf', visible: false) 
-   
-    find("input[name='uploadResume']").click
-    
-    assert_selector "input[value='Success!']" 
-    
-    click_button 'Continue'
-    assert page.has_content?("Confirmation")
-   
-    # let's download it andmake sure its the same
-    assert_selector ".download-resume" 
-    download = open(find(".download-resume")['href'])
-    assert_equal digest, Digest::SHA256.file(download.path)
+      assert page.has_content?("Confirmation")
+     
+      # let's download it andmake sure its the same
+      assert_selector ".download-resume" 
 
-  
+      href = find('.download-resume')['href']
+     
+      page.evaluate_script("window.downloadCSVXHR = function(){ var url = '#{href}'\; return getFile(url)\; }")
+      page.evaluate_script("window.getFile = function(url) { var xhr = new XMLHttpRequest()\;  xhr.open('GET', url, false)\;  xhr.send(null)\; return xhr.status }")
+      assert_equal 200, page.evaluate_script( "downloadCSVXHR()")  
+
+      # and now for fools trying to get in the backdoor
+      err = ->{ open(href) }.must_raise OpenURI::HTTPError 
+      err.message.must_match /403 Forbidden/
+
+    end
   end
   
   scenario 'an applicant cannot upload a none pdf', js: true do
     # we can fast-forward to the available_times step
-   
-    digest= Digest::SHA256.file "test/fixtures/resume.notpdf"
     
     fixture = prospects(:all_valid)
     all_valid = fixture.attributes


### PR DESCRIPTION
… uploading session

Adds a uploader_session_id to the resume table. This is added when a resume is uploaded
by copying the uploader's session ID. The download request then checks if the requestor
is logged in or has the same session id.

https://issues.umd.edu/browse/LIBITD-688