### PR TITLE
LIBITD-708. Allow admins to create resume if not present.

### DIFF
--- a/app/assets/javascripts/prospect.js
+++ b/app/assets/javascripts/prospect.js
@@ -1,6 +1,6 @@
 var init = function() { 
 
-  if ( !$('.container.prospects').length ) { return  }
+  if ( !$('.container.prospects, .container.resumes').length ) { return  }
 
   // this is for adding permanent_addresses. we just want one
   $("#addresses").on('cocoon:after-insert', function() {
@@ -61,6 +61,7 @@ var init = function() {
     var formData = new FormData();
 
     var file =  document.getElementById('resume_file').files[0];
+    var prospect =  document.getElementById('prospect').value;
 
     if (!(/^application\/pdf$/.test(file.type) || /\.pdf$/i.test(file.name))) {
       alert("Not permitted format. Please upload a PDF.");
@@ -68,6 +69,7 @@ var init = function() {
     }
 
     formData.append("resume[file]", file, file.name);
+    formData.append("prospect", prospect);
 
     // in test Rails doesn't do CSRF..
     var $token = $this.find("input[name='authenticity_token']");

--- a/app/controllers/resumes_controller.rb
+++ b/app/controllers/resumes_controller.rb
@@ -1,8 +1,15 @@
 class ResumesController < ApplicationController
+  def new
+    render text: 'forbidden', status: 403, layout: false unless logged_in?
+    @prospect = Prospect.find(params[:prospect])
+    @resume = Resume.new(prospect: @prospect)
+  end
+
   def create
-    @resume = Resume.new(resume_params.merge(upload_session_id: session.id || SecureRandom.hex(16).encode(Encoding::UTF_8)))
+    @resume = Resume.new(resume_params.merge(upload_session_id: upload_session_id))
 
     if @resume.save
+      save_prospect if logged_in? && params[:prospect]
       render json: @resume.to_json(except: :upload_session_id)
     else
       render json: @resume.errors, status: :bad_request
@@ -24,6 +31,7 @@ class ResumesController < ApplicationController
   def edit
     render text: 'forbidden', status: 403, layout: false unless logged_in?
     @resume = Resume.includes(:prospect).find(params[:id])
+    @prospect = Prospect.find_by(resume: @resume)
   end
 
   def update
@@ -43,5 +51,15 @@ class ResumesController < ApplicationController
 
     def same_session?
       @resume.upload_session_id == session.id && !@resume.upload_session_id.blank?
+    end
+
+    def save_prospect
+      @prospect = Prospect.find(params[:prospect])
+      @prospect.resume = @resume
+      @prospect.save
+    end
+
+    def upload_session_id
+      session.id || SecureRandom.hex(16).encode(Encoding::UTF_8)
     end
 end

--- a/app/models/resume.rb
+++ b/app/models/resume.rb
@@ -6,7 +6,7 @@ class Resume < ActiveRecord::Base
   # fix up the MIME type using server-side detection, to overcome browsers
   # sometimes sending incorrect Content-Type headers with PDF files
   # adapted from http://stackoverflow.com/a/7000208/5124907
-  GENERIC_CONTENT_TYPES = ['application/force-download', 'application/octet-stream'].freeze
+  GENERIC_CONTENT_TYPES = ['application/force-download', 'application/octet-stream', 'application/x-download'].freeze
 
   before_validation(on: [:create, :update]) do |resume|
     if GENERIC_CONTENT_TYPES.include?(resume.file_content_type)

--- a/app/views/prospects/_summary.html.erb
+++ b/app/views/prospects/_summary.html.erb
@@ -123,7 +123,7 @@
 <h3>Resume
   <% if @current_user %>
     <% if @current_user.admin %>
-      <%= link_to "Change Resume", edit_resume_path(@resume), class: 'btn btn-info pull-right' %>
+      <%= link_to "Change Resume", @resume ? edit_resume_path(@resume) : new_resume_path(@resume, prospect: @prospect.id), class: 'btn btn-info pull-right' %>
     <% end %>
   <% else %>
     <%= link_to "Change Resume", new_prospect_path(step: "upload_resume"), class: 'btn btn-info pull-right' %>

--- a/app/views/resumes/_form.html.erb
+++ b/app/views/resumes/_form.html.erb
@@ -1,4 +1,5 @@
 <%= simple_form_for @resume,  html: { class: 'form-horizontal uploadForm' } do |resume_form| %>
+  <%= hidden_field_tag :prospect, @prospect.id if @prospect %>
   <%= resume_form.label :file, class: "btn btn-lg btn-info" do %>
     <span class="glyphicon glyphicon-upload" aria-hidden="true"></span>
     Choose a file...

--- a/app/views/resumes/new.html.erb
+++ b/app/views/resumes/new.html.erb
@@ -1,0 +1,3 @@
+<h2>Resume for <%= @resume.prospect.name %></h2>
+<%= render 'form' %>
+<%= link_to "Back", prospect_path(@resume.prospect), class: 'btn btn-default' %>

--- a/test/features/resume_upload_test.rb
+++ b/test/features/resume_upload_test.rb
@@ -2,19 +2,20 @@ require 'open-uri'
 require 'test_helper'
 
 feature 'Upload a resume' do
- 
+
   scenario 'an application can upload a PDF', js: true do
     Capybara.using_session('bad contact info') do
       # we can fast-forward to the available_times step
-     
+
       digest= Digest::SHA256.file "test/fixtures/resume.pdf"
-      
+
       fixture = prospects(:all_valid)
       all_valid = fixture.attributes
       all_valid[:enumeration_ids] = fixture.enumerations.map(&:id)
       all_valid.reject! { |a| %w(id created_at updated_at).include? a }
 
       all_valid['addresses_attributes'] = [addresses(:all_valid_springfield).attributes.reject { |a| a == 'id' }]
+      all_valid['phone_numbers_attributes'] = [phone_numbers(:all_valid_dummy).attributes.reject { |a| a == 'id' }]
       all_valid['available_times_attributes'] = [available_times(:all_valid_sunday).attributes.reject { |a| a == 'id' }]
       page.set_rack_session("prospect_params": all_valid)
 
@@ -24,42 +25,43 @@ feature 'Upload a resume' do
         click_button 'Continue'
         break if page.has_content?('Resume')
       end
-     
+
       assert page.has_content?('Resume')
-      page.attach_file('resume_file', 'test/fixtures/resume.pdf', visible: false) 
-     
+      page.attach_file('resume_file', 'test/fixtures/resume.pdf', visible: false)
+
       find("input[name='uploadResume']").click
-      
-      assert_selector "input[value='Success!']" 
-      
+
+      assert_selector "input[value='Success!']"
+
       click_button 'Continue'
       assert page.has_content?("Confirmation")
-     
+
       # let's download it andmake sure its the same
-      assert_selector ".download-resume" 
+      assert_selector ".download-resume"
 
       href = find('.download-resume')['href']
-     
+
       page.evaluate_script("window.downloadCSVXHR = function(){ var url = '#{href}'\; return getFile(url)\; }")
       page.evaluate_script("window.getFile = function(url) { var xhr = new XMLHttpRequest()\;  xhr.open('GET', url, false)\;  xhr.send(null)\; return xhr.status }")
-      assert_equal 200, page.evaluate_script( "downloadCSVXHR()")  
+      assert_equal 200, page.evaluate_script( "downloadCSVXHR()")
 
       # and now for fools trying to get in the backdoor
-      err = ->{ open(href) }.must_raise OpenURI::HTTPError 
+      err = ->{ open(href) }.must_raise OpenURI::HTTPError
       err.message.must_match /403 Forbidden/
 
     end
   end
-  
+
   scenario 'an applicant cannot upload a none pdf', js: true do
     # we can fast-forward to the available_times step
-    
+
     fixture = prospects(:all_valid)
     all_valid = fixture.attributes
     all_valid[:enumeration_ids] = fixture.enumerations.map(&:id)
     all_valid.reject! { |a| %w(id created_at updated_at).include? a }
 
     all_valid['addresses_attributes'] = [addresses(:all_valid_springfield).attributes.reject { |a| a == 'id' }]
+    all_valid['phone_numbers_attributes'] = [phone_numbers(:all_valid_dummy).attributes.reject { |a| a == 'id' }]
     all_valid['available_times_attributes'] = [available_times(:all_valid_sunday).attributes.reject { |a| a == 'id' }]
     page.set_rack_session("prospect_params": all_valid)
 
@@ -70,17 +72,17 @@ feature 'Upload a resume' do
       break if page.has_content?('Resume')
     end
     assert page.has_content?('Resume')
-    page.attach_file('resume_file', 'test/fixtures/resume.notpdf', visible: false) 
-   
+    page.attach_file('resume_file', 'test/fixtures/resume.notpdf', visible: false)
+
     find("input[name='uploadResume']").click
-    
-    refute_selector "input[value='Success!']" 
-    
+
+    refute_selector "input[value='Success!']"
+
     click_button 'Continue'
     assert page.has_content?("Confirmation")
-   
+
     # let's download it andmake sure its the same
-    refute_selector ".download-resume" 
-  
+    refute_selector ".download-resume"
+
   end
 end


### PR DESCRIPTION
If there is no resume, the admin prospect view links to the resumes#new controller instead of the resumes#{id} controller. This allows the admin users to upload resumes even if the user didn't upload one int he first place, and also to change resumes.

https://issues.umd.edu/browse/LIBITD-708