### PR TITLE
LIBITD-710. Fixed test failures.

### DIFF
--- a/test/features/filter_available_hours_test.rb
+++ b/test/features/filter_available_hours_test.rb
@@ -16,23 +16,23 @@ feature 'Should be able filter prospects on available hours per week' do
     Prospect.find_by( first_name: "Rolling" ).update_attribute( :available_hours_per_week,  40 )
 
     # We should have all of our students present
-    assert page.has_content?("Student, Betty") 
-    assert page.has_content?("Student, Alvin") 
-    assert page.has_content?("Stone, Rolling") 
+    assert page.has_content?("Student, Betty")
+    assert page.has_content?("Student, Alvin")
+    assert page.has_content?("Stone, Rolling")
 
     find("#filter-prospects").click
     assert page.has_content?('Filter Applications')
-  
+
     # we tweak the slider...
-    find(".min-slider-handle").native.drag_by(100, 0);
-    find(".max-slider-handle").native.drag_by(-200, 0);
+    min = drag_until('.min-slider-handle', by: 100) { |v| v > 1 }
+    max = drag_until('.max-slider-handle', by: -100) { |v| v < 40 }
+    sleep(2)
     find("#submit-filter").click
-    sleep(2) 
-    # But only Betty has hours in the  range 
-    
-    assert page.has_content?("Student, Betty") 
-    refute page.has_content?("Student, Alvin") 
-    refute page.has_content?("Stone, Rolling") 
+
+    # But only Betty has hours in the  range
+    assert page.has_content?("Student, Betty")
+    refute page.has_content?("Student, Alvin")
+    refute page.has_content?("Stone, Rolling")
 
   end
 end

--- a/test/features/resume_upload_test.rb
+++ b/test/features/resume_upload_test.rb
@@ -2,19 +2,20 @@ require 'open-uri'
 require 'test_helper'
 
 feature 'Upload a resume' do
- 
+
   scenario 'an application can upload a PDF', js: true do
     Capybara.using_session('bad contact info') do
       # we can fast-forward to the available_times step
-     
+
       digest= Digest::SHA256.file "test/fixtures/resume.pdf"
-      
+
       fixture = prospects(:all_valid)
       all_valid = fixture.attributes
       all_valid[:enumeration_ids] = fixture.enumerations.map(&:id)
       all_valid.reject! { |a| %w(id created_at updated_at).include? a }
 
       all_valid['addresses_attributes'] = [addresses(:all_valid_springfield).attributes.reject { |a| a == 'id' }]
+      all_valid['phone_numbers_attributes'] = [phone_numbers(:all_valid_dummy).attributes.reject { |a| a == 'id' }]
       all_valid['available_times_attributes'] = [available_times(:all_valid_sunday).attributes.reject { |a| a == 'id' }]
       page.set_rack_session("prospect_params": all_valid)
 
@@ -24,42 +25,43 @@ feature 'Upload a resume' do
         click_button 'Continue'
         break if page.has_content?('Resume')
       end
-     
+
       assert page.has_content?('Resume')
-      page.attach_file('resume_file', 'test/fixtures/resume.pdf', visible: false) 
-     
+      page.attach_file('resume_file', 'test/fixtures/resume.pdf', visible: false)
+
       find("input[name='uploadResume']").click
-      
-      assert_selector "input[value='Success!']" 
-      
+
+      assert_selector "input[value='Success!']"
+
       click_button 'Continue'
       assert page.has_content?("Confirmation")
-     
+
       # let's download it andmake sure its the same
-      assert_selector ".download-resume" 
+      assert_selector ".download-resume"
 
       href = find('.download-resume')['href']
-     
+
       page.evaluate_script("window.downloadCSVXHR = function(){ var url = '#{href}'\; return getFile(url)\; }")
       page.evaluate_script("window.getFile = function(url) { var xhr = new XMLHttpRequest()\;  xhr.open('GET', url, false)\;  xhr.send(null)\; return xhr.status }")
-      assert_equal 200, page.evaluate_script( "downloadCSVXHR()")  
+      assert_equal 200, page.evaluate_script( "downloadCSVXHR()")
 
       # and now for fools trying to get in the backdoor
-      err = ->{ open(href) }.must_raise OpenURI::HTTPError 
+      err = ->{ open(href) }.must_raise OpenURI::HTTPError
       err.message.must_match /403 Forbidden/
 
     end
   end
-  
+
   scenario 'an applicant cannot upload a none pdf', js: true do
     # we can fast-forward to the available_times step
-    
+
     fixture = prospects(:all_valid)
     all_valid = fixture.attributes
     all_valid[:enumeration_ids] = fixture.enumerations.map(&:id)
     all_valid.reject! { |a| %w(id created_at updated_at).include? a }
 
     all_valid['addresses_attributes'] = [addresses(:all_valid_springfield).attributes.reject { |a| a == 'id' }]
+    all_valid['phone_numbers_attributes'] = [phone_numbers(:all_valid_dummy).attributes.reject { |a| a == 'id' }]
     all_valid['available_times_attributes'] = [available_times(:all_valid_sunday).attributes.reject { |a| a == 'id' }]
     page.set_rack_session("prospect_params": all_valid)
 
@@ -70,17 +72,17 @@ feature 'Upload a resume' do
       break if page.has_content?('Resume')
     end
     assert page.has_content?('Resume')
-    page.attach_file('resume_file', 'test/fixtures/resume.notpdf', visible: false) 
-   
+    page.attach_file('resume_file', 'test/fixtures/resume.notpdf', visible: false)
+
     find("input[name='uploadResume']").click
-    
-    refute_selector "input[value='Success!']" 
-    
+
+    refute_selector "input[value='Success!']"
+
     click_button 'Continue'
     assert page.has_content?("Confirmation")
-   
+
     # let's download it andmake sure its the same
-    refute_selector ".download-resume" 
-  
+    refute_selector ".download-resume"
+
   end
 end

--- a/test/features/sort_preserves_filter_test.rb
+++ b/test/features/sort_preserves_filter_test.rb
@@ -24,12 +24,13 @@ feature 'Should preserve filter query when sorting' do
     assert page.has_content?('Filter Applications')
 
     # we tweak the slider...
-    find(".min-slider-handle").native.drag_by(100, 0);
-    find(".max-slider-handle").native.drag_by(-200, 0);
-    find("#submit-filter").click
+    min = drag_until('.min-slider-handle', by: 100) { |v| v > 1 }
+    max = drag_until('.max-slider-handle', by: -100) { |v| v < 40 }
+    # wait for the changes to update before submitting
     sleep(2)
-    # But only Betty has hours in the  range
+    find("#submit-filter").click
 
+    # But only Betty has hours in the  range
     assert page.has_content?("Student, Betty")
     refute page.has_content?("Student, Alvin")
     refute page.has_content?("Stone, Rolling")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -75,3 +75,9 @@ class ActiveRecord::Base
   end
 end
 ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
+
+def drag_until(locator, options = {}, &block)
+  slider = find(locator)
+  slider.native.drag_by(options[:by], 0) until block.call(slider['aria-valuenow'].to_i)
+  slider
+end


### PR DESCRIPTION
Main cause of failures appeared to be unreliable timing on setting the slider values. Added a drag_until helper so we can "interactively" drag the slider until it is verified to be at the value we want.

https://issues.umd.edu/browse/LIBITD-710