### PR TITLE
LIBITD-712. Allow admins to edit submitted applications.

### DIFF
--- a/app/assets/javascripts/prospect.js
+++ b/app/assets/javascripts/prospect.js
@@ -37,14 +37,16 @@ var init = function() {
   // this hides the checkboxes on the availability table. 
   $("#availability-table > tbody > tr > td  input").hide();
 
-  $(".availability-availability-table > tbody > tr > td:not(.time-label) ").on("click", function(event) {
-    var $this = $(this); 
-    $this.toggleClass("success");
-    $this.toggleClass("warning"); 
+  if ($('.container.prospects.create, .container.prospects.new, .container.prospects.edit').length) {
+    $("#availability-table > tbody > tr > td:not(.time-label) ").on("click", function(event) {
+      var $this = $(this); 
+      $this.toggleClass("success");
+      $this.toggleClass("warning"); 
 
-    var checkbox =  $this.find("input");
-    checkbox.prop("checked", !checkbox.prop("checked"));
-  })
+      var checkbox =  $this.find("input");
+      checkbox.prop("checked", !checkbox.prop("checked"));
+    })
+  }
 
   // For the file upload bits
   $("input#resume_file").on("change", function(e) { 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,10 +58,14 @@ label.required abbr {
 }
 
 /* only for tables on the availability step */
-.availability-availability-table > tbody > tr >  td:not(.time-label) { cursor: pointer; }
-.availability-availability-table > tbody > tr >  td:not(.time-label):hover {
-  border-color: #5cb85c;
-  background: #dff0d8;
+.container.prospects {
+  &.new, &.create, &.edit {
+    #availability-table > tbody > tr >  td:not(.time-label) { cursor: pointer; }
+    #availability-table > tbody > tr >  td:not(.time-label):hover {
+      border-color: #5cb85c;
+      background: #dff0d8;
+    }
+  }
 }
 
 .avail-cell.success:after {

--- a/app/views/prospects/edit.html.erb
+++ b/app/views/prospects/edit.html.erb
@@ -1,0 +1,26 @@
+<%= simple_form_for @prospect,  html: { class: 'form-horizontal' },
+  wrapper_mappings: {
+    check_boxes: :horizontal_radio_and_checkboxes,
+    radio_buttons: :vertical_radio_and_checkboxes,
+    file: :horizontal_file_input,
+    boolean: :horizontal_boolean
+  } do |form| %>
+  <%= form.error_notification %> 
+  <%= render 'contact_info_step', form: form %>
+  <%= render 'work_experience_step', form: form %>
+  <%= render 'skills_step', form: form %>
+  <%= render 'availability_step', form: form %>
+  <h3>Resume
+    <% if @current_user %>
+      <% if @current_user.admin %>
+        <%= link_to "Change Resume", @resume ? edit_resume_path(@resume) : new_resume_path(@resume, prospect: @prospect.id), class: 'btn btn-info pull-right' %>
+      <% end %>
+    <% else %>
+      <%= link_to "Change Resume", new_prospect_path(step: "upload_resume"), class: 'btn btn-info pull-right' %>
+    <% end %>
+  </h3>
+  <div class="well">
+    <%= link_to 'Back', prospect_path(@prospect), class: 'btn btn-default' %>
+    <%= form.submit 'Save', class: 'btn btn-success' %>
+  </div>
+<% end %>

--- a/app/views/prospects/show.html.erb
+++ b/app/views/prospects/show.html.erb
@@ -1,4 +1,7 @@
 <%= simple_form_for @prospect,  html: { class: 'form-horizontal' } do |form| %>
   <%= render partial: "summary", locals: { form: form } %>
+  <div class="well">
+    <%= link_to 'Edit Submission', edit_prospect_path(@prospect), class: 'btn btn-info' %>
+  </div>
   <%= render(partial: "admin_section", locals: { form: form }) if @current_user.admin? %>
 <% end %>

--- a/test/features/admin_edit_test.rb
+++ b/test/features/admin_edit_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+feature 'Admins can edit submitted applications' do
+  scenario 'login as admin & edit submitted application', js: true do
+    page.driver.resize_window(2048, 2048)
+
+    User.create(cas_directory_id: 'editor', name: 'editor', admin: true)
+    visit prospects_path
+    fill_in 'username', with: 'editor'
+    fill_in 'password', with: 'any password'
+    click_button 'Login'
+
+    # We should have all of our students present
+    assert page.has_content?("Student, Betty")
+    assert page.has_content?("Student, Alvin")
+    assert page.has_content?("Stone, Rolling")
+
+    find_link('Student, Betty').click
+    find_link('Edit Submission').click
+    fill_in 'prospect[first_name]', with: 'Cassie'
+    fill_in 'prospect[last_name]', with: 'Nova'
+    find_button('Save').click
+
+    # We should have all of our students present, but Betty's name has changed
+    refute page.has_content?("Student, Betty")
+    assert page.has_content?("Nova, Cassie")
+    assert page.has_content?("Student, Alvin")
+    assert page.has_content?("Stone, Rolling")
+
+  end
+end


### PR DESCRIPTION
Added an edit form to the prospects controller, along with an acceptance test to confirm that admins can edit submitted applications. Changed the application.css to application.scss for more understandable selectors.

https://issues.umd.edu/browse/LIBITD-712