### PR TITLE
LIBITD-719 Ensure changing day_times doesn't trigger dependency destroy

### DIFF
--- a/app/models/available_time.rb
+++ b/app/models/available_time.rb
@@ -1,6 +1,6 @@
 # Times of day the applicant is available to work
 class AvailableTime < ActiveRecord::Base
-  belongs_to :prospect, dependent: :destroy, counter_cache: true
+  belongs_to :prospect,  counter_cache: true
   enum day: %i(sunday monday tuesday wednesday thursday friday saturday)
 
   attr_writer :day_time

--- a/app/models/prospect.rb
+++ b/app/models/prospect.rb
@@ -110,12 +110,15 @@ class Prospect < ActiveRecord::Base
   end
 
   def day_times=(dts)
-    available_times.destroy_all
+    unless dts == @day_times 
+      instance_variable_set(:@changed_attributes, { day_times: @day_times }) 
+    end 
+    available_times.each { |at| at.mark_for_destruction } 
     dts.each do |dt|
       day, time = dt.split('-').map(&:to_i)
-      available_times.find_or_initialize_by(day: day, time: time)
+      available_times.build(day: day, time: time)
     end
-    @day_times = available_times.map(&:day_time)
+    @day_times = available_times.map { |at| at.day_time unless at.marked_for_destruction? }.compact
   end
 
   has_many :phone_numbers, inverse_of: :prospect, dependent: :destroy

--- a/test/features/configuration_test.rb
+++ b/test/features/configuration_test.rb
@@ -53,6 +53,7 @@ feature 'Should be able to configuration that application' do
     refute enum.reload.active? 
     find(:css, "#enumeration_#{enum.id} .toggle").trigger(:click)
     page.must_have_selector  "#enumeration_#{enum.id} .toggle:not(.off)"
+    sleep(1) 
     assert enum.reload.active? 
   end
   

--- a/test/models/prospect_test.rb
+++ b/test/models/prospect_test.rb
@@ -83,6 +83,17 @@ class ProspectTest < ActiveSupport::TestCase
       assert_includes prospect.day_times, a.day_time
     end
   end
+  
+  test 'it should be able to modify available_times via the day_times shortcut' do
+    prospect = prospects(:all_valid) 
+    dts = prospect.day_times
+    assert_equal prospect.available_times.length, dts.length
+    new_dts=  [ "0-13", "1-14", "2-15", "3-16", "4-17", "5-18", "6-19" ] 
+    prospect.day_times = new_dts 
+    assert prospect.changed? 
+    assert prospect.save!
+    assert_equal prospect.day_times, new_dts
+  end
 
   test 'it ensure the total available hours is not more than the available_times selected' do
     assert_equal @all_valid.available_hours_per_week, 1


### PR DESCRIPTION
Currently using the #day_times method causes the Prospect to be deleted as part of the
dependency to available_times. This cleans that up, and also uses the mark_for_deletion,
to ensure changes are not committed until #save is called.

https://issues.umd.edu/browse/LIBITD-719