### PR TITLE
LIBITD-724 Move notificaition emails to deliver_later

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,10 @@ gem 'will_paginate-bootstrap'
 
 gem 'paperclip', '~> 5.0.0'
 
+gem 'delayed_job_active_record'
+gem "delayed_job_web"
+gem "daemons"
+
 gem 'faker'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     capistrano-rails (1.2.2)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capybara (2.11.0)
+    capybara (2.12.0)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -95,8 +95,18 @@ GEM
     country_select (3.0.0)
       countries (~> 2.0)
       sort_alphabetical (~> 1.0)
+    daemons (1.2.4)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
+    delayed_job (4.1.2)
+      activesupport (>= 3.0, < 5.1)
+    delayed_job_active_record (4.1.1)
+      activerecord (>= 3.0, < 5.1)
+      delayed_job (>= 3.0, < 5)
+    delayed_job_web (1.2.10)
+      activerecord (> 3.0.0)
+      delayed_job (> 2.0.3)
+      sinatra (>= 1.4.4)
     docile (1.1.5)
     dotenv (2.1.2)
     dotenv-rails (2.1.2)
@@ -168,7 +178,7 @@ GEM
       minitest-capybara (~> 0.8)
       minitest-metadata (~> 0.6)
       minitest-rails (~> 2.1)
-    minitest-reporters (1.1.13)
+    minitest-reporters (1.1.14)
       ansi
       builder
       minitest (>= 5.0)
@@ -197,7 +207,7 @@ GEM
     parser (2.3.3.1)
       ast (~> 2.2)
     pg (0.19.0)
-    poltergeist (1.12.0)
+    poltergeist (1.13.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
@@ -214,6 +224,8 @@ GEM
       addressable (~> 2.3)
       nokogiri (~> 1.5)
       rack (>= 1.3)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rack_session_access (0.1.1)
@@ -246,7 +258,7 @@ GEM
     rainbow (2.2.1)
     rake (12.0.0)
     rb-fsevent (0.9.8)
-    rb-inotify (0.9.7)
+    rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     rdoc (4.3.0)
     rubocop (0.47.1)
@@ -274,16 +286,20 @@ GEM
     simple_form (3.4.0)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
-    simplecov (0.12.0)
+    simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    sinatra (1.4.7)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
     sixarm_ruby_unaccent (1.1.1)
     slop (3.6.0)
     sort_alphabetical (1.1.0)
       unicode_utils (>= 1.2.2)
-    spring (2.0.0)
+    spring (2.0.1)
       activesupport (>= 4.2)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
@@ -301,7 +317,7 @@ GEM
       activerecord (>= 3.2)
     thor (0.19.4)
     thread_safe (0.3.5)
-    tilt (2.0.5)
+    tilt (2.0.6)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)
@@ -316,7 +332,7 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-    websocket-driver (0.6.4)
+    websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     will_paginate (3.1.5)
@@ -336,7 +352,10 @@ DEPENDENCIES
   cocoon
   connection_pool
   country_select
+  daemons
   database_cleaner
+  delayed_job_active_record
+  delayed_job_web
   dotenv-rails (~> 2.1.1)
   faker
   figaro

--- a/README.md
+++ b/README.md
@@ -65,10 +65,28 @@ provided to assist with this process. Simply copy the "env_example" file to
 The configured .env file should _not_ be checked into the Git repository, as it
 contains credential information.
 
+### Delayed Jobs and Mailers
+
+An application submission sends an email to applicants. This email is handled
+by ActionMailer, using a [delayed_job](https://github.com/collectiveidea/delayed_job) queue.
+To run a delayed_job worker, you can start/stop the daemon process using :
+
+```
+$ ./bin/delayed_job start RAILS_ENV=production 
+$ ./bin/delayed_job stop RAILS_ENV=production 
+```
+
+To view the delayed_job queue status, you can visit /delayed_job in the
+application. This requires an admin user to be logged in ( first visit
+/prospects to login. )
+
+
 ### Adding users
 
 You can add users via a rake task: 
 
-rake db:add_admin_cas_user[cas_directory_id,full_name]  # Add an admin user
-rake db:add_cas_user[cas_directory_id,full_name]        # Add a non-admin user
-rake db:bulk_add_users[csv_file]  # use csv file with full_name, directory_id rows 
+```
+$ ./bin/rake db:add_admin_cas_user[cas_directory_id,full_name]  # Add an admin user
+$ ./bin/rake db:add_cas_user[cas_directory_id,full_name]        # Add a non-admin user
+$ ./bin/rake db:bulk_add_users[csv_file]  # use csv file with full_name, directory_id rows 
+```

--- a/app/controllers/prospects_controller.rb
+++ b/app/controllers/prospects_controller.rb
@@ -31,7 +31,7 @@ class ProspectsController < ApplicationController
       render 'new'
     elsif @prospect
       begin 
-        SubmittedMailer.default_email(@prospect).deliver_now
+        SubmittedMailer.default_email(@prospect).deliver_later
      	rescue  EOFError,
 							IOError,
 							TimeoutError,

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ module OnlineStudentApplications
     config.rack_cas.server_url = 'https://login.umd.edu/cas' 
     config.rack_cas.session_store = RackCAS::ActiveRecordStore 
 
+    config.active_job.queue_adapter = :delayed_job
 
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,6 @@ Rails.application.configure do
   config.middleware.use RackSessionAccess::Middleware
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.active_job.queue_adapter = :inline
 end

--- a/config/initializers/delayed_job_web.rb
+++ b/config/initializers/delayed_job_web.rb
@@ -1,0 +1,18 @@
+require 'delayed_job_web'
+
+class DelayedJobWeb < Sinatra::Base
+  
+	def logged_in_and_admin?
+    return false if session[:cas].nil? || session[:cas][:user].nil?
+    user = User.find_by(cas_directory_id: session[:cas][:user])
+    return ( user && user.admin? ) 
+  end
+
+	before do 
+		if logged_in_and_admin? 
+			return true	
+		end
+		halt "Unauthorized"		
+	end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,4 +19,8 @@ Rails.application.routes.draw do
 
   get 'configuration' => 'configuration#show', as: :configuration
   post 'configuration' => 'configuration#update', as: :update_configuration
+
+  match "/delayed_jobs" => DelayedJobWeb, anchor: false, via: [:get, :post]
+
+
 end

--- a/db/migrate/20170127130407_create_delayed_jobs.rb
+++ b/db/migrate/20170127130407_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170110065805) do
+ActiveRecord::Schema.define(version: 20170127130407) do
 
   create_table "addresses", force: :cascade do |t|
     t.string  "street_address_1"
@@ -33,6 +33,22 @@ ActiveRecord::Schema.define(version: 20170110065805) do
   end
 
   add_index "available_times", ["prospect_id"], name: "index_available_times_on_prospect_id"
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer  "priority",   default: 0, null: false
+    t.integer  "attempts",   default: 0, null: false
+    t.text     "handler",                null: false
+    t.text     "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string   "locked_by"
+    t.string   "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority"
 
   create_table "enumerations", force: :cascade do |t|
     t.string  "value",                   null: false

--- a/test/features/delayed_jobs_test.rb
+++ b/test/features/delayed_jobs_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+feature 'Admins can see the delayed jobs page' do
+  scenario 'admins can see the delayed job page', js: true do
+    User.create(cas_directory_id: 'editor', name: 'editor', admin: true)
+    visit prospects_path
+    fill_in 'username', with: 'editor'
+    fill_in 'password', with: 'any password'
+    click_button 'Login'
+    
+    visit "/delayed_jobs"
+
+    assert page.has_content?("Overview")
+
+  end
+  
+  scenario 'nonadmins cannot see the delayed job page', js: true do
+    User.create(cas_directory_id: 'someone', name: 'someone', admin: false)
+    visit prospects_path
+    fill_in 'username', with: 'someone'
+    fill_in 'password', with: 'any password'
+    click_button 'Login'
+    
+    visit "/delayed_jobs"
+
+    assert page.has_content?("Unauthorized")
+
+  end
+  
+  scenario 'unauthed visitors cannot see the delayed job page', js: true do
+    visit "/delayed_jobs"
+    assert page.has_content?("Unauthorized")
+  end
+
+end


### PR DESCRIPTION
This make the ActionMailer set to a deliver_later method, which places email
delivery on a delayed_job queue. This allows for email delivery issues to not
block application submission.

Also added the delayed_job_web sinatra application which allows for a dashboard
for the job queue at /delayed_job

https://issues.umd.edu/browse/LIBITD-724