### PR TITLE
LIBITD-765. Added gems and configuration to support Jenkins reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,8 +76,6 @@ group :development do
   gem 'rb-fsevent', require: false
   gem 'ruby_dep', '~> 1.3.1'
   gem 'terminal-notifier-guard', require: false
-
-  gem 'rubocop'
 end
 
 group :test do
@@ -93,6 +91,11 @@ group :test do
   gem 'rack_session_access'
   gem 'shoulda-context'
   gem 'shoulda-matchers', '>= 3.0.1'
-  gem 'simplecov', require: false
   gem 'test_after_commit'
+
+  # Code analysis tools
+  gem 'rubocop', require: false
+  gem 'rubocop-checkstyle_formatter', require: false
+  gem 'simplecov', require: false
+  gem 'simplecov-rcov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,8 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-checkstyle_formatter (0.2.0)
+      rubocop (>= 0.20.1)
     ruby-progressbar (1.8.1)
     ruby_dep (1.3.1)
     sass (3.4.23)
@@ -291,6 +293,8 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    simplecov-rcov (0.2.3)
+      simplecov (>= 0.4.1)
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -376,6 +380,7 @@ DEPENDENCIES
   rails (= 4.2.6)
   rb-fsevent
   rubocop
+  rubocop-checkstyle_formatter
   ruby_dep (~> 1.3.1)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
@@ -383,6 +388,7 @@ DEPENDENCIES
   shoulda-matchers (>= 3.0.1)
   simple_form
   simplecov
+  simplecov-rcov
   spring
   sqlite3
   terminal-notifier-guard

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,12 @@
 require 'simplecov'
+require 'simplecov-rcov'
 require 'database_cleaner'
 
+SimpleCov.formatters = [
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::RcovFormatter
+]
 SimpleCov.start
-
 
 require 'securerandom'
 


### PR DESCRIPTION
Added "rubocop-checkstyle_formatter" and "simplecov-rcov" gems to
support generating Rubocop and simplecov reports that can be processed
by the Jenkins continuous integration application.

Updated "test_helper.rb" to produce reports needed for Jenkins.

Moved the "rubocop" and "simplecov" gems into the "test" group, to make
consistent with the annual-staffing-request project.

https://issues.umd.edu/browse/LIBITD-765