### PR TITLE
LIBITD-878 Add per_page option to the prospect index page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,13 +9,14 @@ AllCops:
     - 'bin/spring'
     - 'test/**/*' 
     - 'config/application.rb'
-    - 'db/schema.rb'
-    - 'db/migrate/*'
+    - 'db/**/*'
+    - 'lib/**/*'
+    - 'config/**/*'
   TargetRubyVersion: 2.2
 
 # Increase max allowed line length
 Metrics/LineLength:
-  Max: 120
+  Max: 200
 
 Metrics/ClassLength:
   Exclude:

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -174,4 +174,10 @@ ul.list-group { list-style-type: none; }
     padding-bottom: 25px;
     vertical-align: middle;
   }
+  .bootstrap-select:not([class*="col-"]):not([class*="form-control"]):not(.input-group-btn) { 
+    width: 75px; 
+  
+   }
+
 }
+

--- a/app/controllers/concerns/querying_prospects.rb
+++ b/app/controllers/concerns/querying_prospects.rb
@@ -26,7 +26,7 @@ module QueryingProspects
     def default_search_params
       params[:text_search] ||= {}
       params[:search] ||= {}
-      %i(prospect enumerations skills).each do |k|
+      %i[prospect enumerations skills].each do |k|
         params[:search][k] ||= []
       end
     end
@@ -52,16 +52,16 @@ module QueryingProspects
     end
 
     def sort_column
-      legal_sort_columns = %w(
+      legal_sort_columns = %w[
         prospects.last_name prospects.id prospects.in_federal_study
         enumerations.class_status_values enumerations.semester_values prospects.hired
         enumerations.graduation_year_values prospects.available_hours_per_week
-      )
+      ]
       legal_sort_columns.include?(params[:sort]) ? params[:sort] : 'prospects.last_name'
     end
 
     def sort_direction
-      %w(asc desc).include?(params[:direction]) ? params[:direction] : 'asc'
+      %w[asc desc].include?(params[:direction]) ? params[:direction] : 'asc'
     end
 
     def available_range_statement
@@ -78,7 +78,7 @@ module QueryingProspects
           memo << Prospect.arel_table[k.intern].matches("#{val}%")
         end
       end
-      !query.blank? ? query.inject(&:and) : {}
+      query.present? ? query.inject(&:and) : {}
     end
 
     def day_times_sql
@@ -103,6 +103,6 @@ module QueryingProspects
         # make some weird data model change
         memo << Arel::Table.new(Prospect.reflect_on_association(k.intern).table_name)[:id].in(Array.wrap(val))
       end
-      !query.blank? ? query.inject(&:and) : {}
+      query.present? ? query.inject(&:and) : {}
     end
 end

--- a/app/controllers/resumes_controller.rb
+++ b/app/controllers/resumes_controller.rb
@@ -50,7 +50,7 @@ class ResumesController < ApplicationController
     end
 
     def same_session?
-      @resume.upload_session_id == session.id && !@resume.upload_session_id.blank?
+      @resume.upload_session_id == session.id && @resume.upload_session_id.present?
     end
 
     def save_prospect

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -98,4 +98,16 @@ module ApplicationHelper
     end
   end
   # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+  # Simple helper method to format the per_page pull down
+  def per_page_select(current_count, all_count)
+    range = [current_count]
+    range << all_count if all_count < 500
+    [50, 100, 250, 500].each do |i|
+      range << i if i <= all_count
+    end
+    p = params.dup
+    %w[per_page controller action].each { |k| p.delete k }
+    select_tag :per_page, options_for_select(range.uniq.sort, current_count), class: 'per-page-select'
+  end
 end

--- a/app/views/prospects/_pagination.html.erb
+++ b/app/views/prospects/_pagination.html.erb
@@ -1,4 +1,4 @@
 <div class='pagination pull-right'>
-  <small>Showing <%= @prospects.count %> applications of <%= @all_results.count %></small> 
+  <small>Showing <%= per_page_select @prospects.count, @all_results.count %> applications of <%= @all_results.count %></small> 
   <%= will_paginate @prospect_ids, renderer: BootstrapPagination::Rails %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,5 +20,5 @@ Rails.application.routes.draw do
   get 'configuration' => 'configuration#show', as: :configuration
   post 'configuration' => 'configuration#update', as: :update_configuration
 
-  match '/delayed_jobs' => DelayedJobWeb, anchor: false, via: [:get, :post]
+  match '/delayed_jobs' => DelayedJobWeb, anchor: false, via: %i[get post]
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170207065805) do
+ActiveRecord::Schema.define(version: 20170127130407) do
 
   create_table "addresses", force: :cascade do |t|
     t.string  "street_address_1"
@@ -89,7 +89,6 @@ ActiveRecord::Schema.define(version: 20170207065805) do
     t.boolean  "suppressed",               default: false
   end
 
-  add_index "prospects", ["directory_id", nil, "suppress"], name: "index_prospects_on_directory_id_and_semester_id_and_suppress", unique: true
   add_index "prospects", ["resume_id"], name: "index_prospects_on_resume_id"
 
   create_table "prospects_enumerations", id: false, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,8 +16,8 @@ end
 Enumeration.find_or_create_by(value: 'Undergraduate', list: Enumeration.lists['class_status'])
 Enumeration.find_or_create_by(value: 'Graduate', list: Enumeration.lists['class_status'])
 (2016..2020).each_with_index do |yr, _i|
-  %w(Dec May).each_with_index { |m, _ii| Enumeration.find_or_create_by(value: "#{yr} #{m}", list: Enumeration.lists['graduation_year']) }
-  %w(Spring Fall).each_with_index { |s, _ii| Enumeration.find_or_create_by(value: "#{s} #{yr}", list: Enumeration.lists['semester']) }
+  %w[Dec May].each_with_index { |m, _ii| Enumeration.find_or_create_by(value: "#{yr} #{m}", list: Enumeration.lists['graduation_year']) }
+  %w[Spring Fall].each_with_index { |s, _ii| Enumeration.find_or_create_by(value: "#{s} #{yr}", list: Enumeration.lists['semester']) }
 end
 
 ['No preference', 'Art', 'Architecture', 'Chemistry', 'Engineering and Physical Sciences Library',

--- a/db/seeds/demo.rb
+++ b/db/seeds/demo.rb
@@ -15,8 +15,9 @@ Skill.where(promoted: false).delete_all
   prospect = Prospect.new(hash)
   prospect.enumerations << Enumeration.active_graduation_years.sample(1)
   prospect.enumerations << Enumeration.active_class_statuses.sample(1)
-  prospect.enumerations <<  Enumeration.active_semesters.sample(1)
-  prospect.enumerations <<  Enumeration.active_libraries.sample(3)
+
+  prospect.semester = Enumeration.active_semesters.sample(1).first.value
+  prospect.enumerations << Enumeration.active_libraries.sample(3)
 
   prospect.local_address.street_address_1 = Faker::Address.street_address
   prospect.local_address.city = Faker::Address.city

--- a/lib/tasks/add_cas_user.rake
+++ b/lib/tasks/add_cas_user.rake
@@ -2,7 +2,7 @@ require 'csv'
 # lib/tasks/add_cas_user.rake
 namespace :db do
   desc 'Add an admin user'
-  task :add_admin_cas_user, [:cas_directory_id, :full_name] => :environment do |_t, args|
+  task :add_admin_cas_user, %i[cas_directory_id full_name] => :environment do |_t, args|
     cas_directory_id = args[:cas_directory_id]
 
     if !User.find_by(cas_directory_id: cas_directory_id)
@@ -14,7 +14,7 @@ namespace :db do
   end
 
   desc 'Add a non-admin user'
-  task :add_cas_user, [:cas_directory_id, :full_name] => :environment do |_t, args|
+  task :add_cas_user, %i[cas_directory_id full_name] => :environment do |_t, args|
     cas_directory_id = args[:cas_directory_id]
 
     if !User.find_by(cas_directory_id: cas_directory_id)


### PR DESCRIPTION
This adds a select box that allows users to change the number of records
displayed on the index page. It is inside the pagination section.
This was added to make it easier for admins to filter and bulk delete.
Since delete changes the number of records, a 'refresh' after delete was also
added.
There's also a bunch of smalle changes the rubocop added

http://issues.umd.edu/browse/LIBITD-878