### PR TITLE
LIBITD-1075. Fixed Rubocop warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   Exclude:
     - 'bin/setup'
     - 'bin/spring'
-    - 'test/**/*' 
+    - 'test/**/*'
     - 'config/application.rb'
     - 'db/**/*'
     - 'lib/**/*'
@@ -39,3 +39,21 @@ Style/ClassAndModuleChildren:
 
 Style/IndentationConsistency:
   EnforcedStyle: rails
+
+# May want to reconsider these exclusions in the future
+Rails/HasAndBelongsToMany:
+  Exclude:
+    - 'app/models/enumeration.rb'
+    - 'app/models/skill.rb'
+
+Rails/SkipsModelValidations:
+  Exclude:
+    - 'app/controllers/configuration_controller.rb'
+    - 'app/controllers/prospects_controller.rb'
+
+Style/PercentLiteralDelimiters:
+  Exclude:
+    - 'app/controllers/prospects_controller.rb'
+    - 'app/controllers/concerns/querying_prospects.rb'
+    - 'app/helpers/application_helper.rb'
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,11 +9,13 @@ class ApplicationController < ActionController::Base
     redirect_to root_url, flash: { notice: 'Application has been reset due to session inactivity.' }
   end
 
+  # rubocop:disable Style/GuardClause
   def fix_cas_session
     if session[:cas] && !session[:cas].is_a?(HashWithIndifferentAccess)
       session[:cas] = session[:cas].with_indifferent_access
     end
   end
+  # rubocop:enable Style/GuardClause
 
   # just returns tue if the user is logged in. does not redirect
   # if not logged in
@@ -23,7 +25,7 @@ class ApplicationController < ActionController::Base
   end
 
   # this logs the user in.
-  def ensure_auth
+  def ensure_auth # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     if session[:prospect_params]
       # we have an application going so we've probably just refreshed the
       # screen
@@ -41,12 +43,14 @@ class ApplicationController < ActionController::Base
     nil
   end
 
+  # rubocop:disable Style/GuardClause
   def ensure_admin
     unless @current_user.admin?
       flash[:alert] = 'Access Denied'
       redirect_to root_url
     end
   end
+  # rubocop:enable Style/GuardClause
 
   private
 

--- a/app/controllers/concerns/querying_prospects.rb
+++ b/app/controllers/concerns/querying_prospects.rb
@@ -6,7 +6,7 @@ module QueryingProspects
   end
 
   # this is pretty hacky. would be nice to refactor with arel.
-  def sort_order
+  def sort_order # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     col = sort_column
     # do a case-insensitive sort if we are sort on last name
     col = "lower(#{col})" if col.include?('last_name')
@@ -31,7 +31,7 @@ module QueryingProspects
       end
     end
 
-    def join_table
+    def join_table # rubocop:disable Metrics/AbcSize
       join_tables = []
       if Prospect.reflections.keys.include?(sort_column.split('.').first)
         join_tables << sort_column.split('.').first.intern

--- a/app/controllers/configuration_controller.rb
+++ b/app/controllers/configuration_controller.rb
@@ -14,7 +14,7 @@ class ConfigurationController < ApplicationController
   # 3) Toggle Enumeration active boolean ( pass in id in :toggle_active_id )
   # 4) Create an new enuemration ( in :enumeration param )
   # 5) Create a new skill
-  def update
+  def update # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     if params.key?(:update_positions_ids) # this just resets the list of enum values
       render json: Enumeration.update_positions(params[:update_positions_ids]).map(&:id)
     elsif params.key?(:toggle_promoted_id)

--- a/app/controllers/prospects_controller.rb
+++ b/app/controllers/prospects_controller.rb
@@ -1,4 +1,4 @@
-class ProspectsController < ApplicationController
+class ProspectsController < ApplicationController # rubocop:disable Metrics/ClassLength
   include QueryingProspects
 
   @error_message = "We're sorry, but something has gone wrong. Please try again."
@@ -11,7 +11,7 @@ class ProspectsController < ApplicationController
     choose_action if params[:step]
   end
 
-  def create
+  def create # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     if params[:reset]
       redirect_to reset_url
     else
@@ -30,7 +30,7 @@ class ProspectsController < ApplicationController
     elsif @prospect
       begin
           SubmittedMailer.default_email(@prospect).deliver_later
-        rescue EOFError,
+        rescue EOFError, # rubocop:disable Lint/ShadowedException
                IOError,
                TimeoutError,
                Errno::ECONNRESET,
@@ -73,7 +73,7 @@ class ProspectsController < ApplicationController
     @resume = @prospect.resume
   end
 
-  def update
+  def update # rubocop:disable Metrics/AbcSize
     @prospect = Prospect.includes(:enumerations, :available_times, :skills).find(params[:id])
     if @prospect.update(prospect_params)
       redirect_to prospects_path, notice: "#{@prospect.name} application has been updated"
@@ -99,7 +99,7 @@ class ProspectsController < ApplicationController
 
   private
 
-    def log_exception(exception, prospect = nil)
+    def log_exception(exception, prospect = nil) # rubocop:disable Metrics/AbcSize
       logger.error '~' * 100
       logger.error 'Application Submission Failure!'
       logger.error "Prospect: #{prospect.inspect} Errors: #{prospect.errors}" if prospect
@@ -124,7 +124,7 @@ class ProspectsController < ApplicationController
 
     # match the value stored in the session with the incoming values in the
     # param
-    def set_session
+    def set_session # rubocop:disable Metrics/AbcSize
       session[:prospect_params] ||= {}.with_indifferent_access
       session[:prospect_params].deep_merge!(prospect_params)
       session[:prospect_params].keys.select { |a| a =~ /_attributes$/ }.each do |attr|
@@ -135,7 +135,7 @@ class ProspectsController < ApplicationController
       end
     end
 
-    def set_prospect
+    def set_prospect # rubocop:disable Metrics/AbcSize
       @prospect = Prospect.new(ActionController::Parameters.new(session[:prospect_params]).permit!)
       if @prospect.nil? || !@prospect.is_a?(Prospect)
         reset_session
@@ -155,7 +155,7 @@ class ProspectsController < ApplicationController
       params.require(:prospect).permit(*whitelisted_attrs)
     end
 
-    def whitelisted_attrs
+    def whitelisted_attrs # rubocop:disable Metrics/MethodLength
       # these are all the single keys that are allowed.
       attrs = %i[
         current_step commit in_federal_study directory_id first_name last_name
@@ -185,7 +185,7 @@ class ProspectsController < ApplicationController
     end
 
     # decide which step to move to depending on which button was clicked and which step we are already on
-    def choose_action
+    def choose_action # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       if params[:back_button]
         @prospect.previous_step
       elsif params[:step]
@@ -201,7 +201,7 @@ class ProspectsController < ApplicationController
       raise e
     end
 
-    def find_prospects
+    def find_prospects # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       @all_results = Prospect.joins(join_table).select(select_statement)
                              .where(text_search_statement)
                              .where(search_statement)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :ensure_auth
   before_action :ensure_admin, except: :disable_admin
 
-  def create
+  def create # rubocop:disable Metrics/AbcSize
     @user = User.new(user_params)
     respond_to do |format|
       format.json do

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,4 @@
+# Base class for mailers
 class ApplicationMailer < ActionMailer::Base
   default from: 'from@example.com'
   layout 'mailer'

--- a/app/models/enumeration.rb
+++ b/app/models/enumeration.rb
@@ -1,3 +1,4 @@
+# Model for enumerated values
 class Enumeration < ActiveRecord::Base
   has_and_belongs_to_many :prospects, join_table: 'prospects_enumerations'
 
@@ -26,7 +27,10 @@ class Enumeration < ActiveRecord::Base
     # this takes an array of key values and updates the positions based on
     # their position in the array.
     def update_positions(ids)
-      positions = *(0..ids.length).each_with_object([]) { |v, m| m << { position: v }; m }
+      positions = *(0..ids.length).each_with_object([]) do |v, m|
+        m << { position: v }
+        m
+      end
       Enumeration.update(ids, positions)
     end
   end

--- a/app/models/phone_number.rb
+++ b/app/models/phone_number.rb
@@ -1,3 +1,4 @@
+# A phone number for the prospect
 class PhoneNumber < ActiveRecord::Base
   belongs_to :prospect
   validates :prospect, presence: true

--- a/app/models/prospect.rb
+++ b/app/models/prospect.rb
@@ -28,6 +28,7 @@ class Prospect < ActiveRecord::Base
   # Custom Validations
   validate :must_have_class_status, :must_have_graduation_year, :must_have_semester, :only_one_id_per_semester
 
+  # rubocop:disable Style/GuardClause, Metrics/LineLength, Rails/OutputSafety
   def only_one_id_per_semester
     if current_step == 'id_and_semester' && !persisted? && semester
       if Prospect.joins(:enumerations).where(suppressed: false, directory_id: directory_id, enumerations: { id: semester.id }).exists?
@@ -35,8 +36,8 @@ class Prospect < ActiveRecord::Base
       end
     end
   end
+  # rubocop:enable Metrics/LineLength, Rails/OutputSafety
 
-  # rubocop:disable Style/GuardClause
   def must_have_class_status
     if current_step == 'contact_info' && class_status.nil?
       errors.add(:class_status, 'You must have one ( and only one ) Class Status selected.')
@@ -54,7 +55,7 @@ class Prospect < ActiveRecord::Base
       errors.add(:semester, 'Please indicate which semester you are applying for.')
     end
   end
-  # rubocop:enable Style/GuardClause
+  # rubocop:enable Style/GuardClause, Metrics/LineLength
 
   attr_accessor :class_status
   def class_status
@@ -71,7 +72,7 @@ class Prospect < ActiveRecord::Base
   #  enumerations.find { |e| e['list'] == Enumeration.lists['semester'] }
   # end
 
-  def semester=(value)
+  def semester=(value) # rubocop:disable Metrics/AbcSize
     return if value.nil?
 
     current = @semester.nil? ? enumerations.find { |e| e['list'] == Enumeration.lists['semester'] } : @semester


### PR DESCRIPTION
Fixed Rubocop warnings, generally by adding "rubocop:disable" comments
to the affected files.

Added additional exclusions to .rubocop.yml file for some rules that we
may wish to reconsider in the future.

In app/models/enumeration.rb, changed a multiline block using braces to
a "do/end" block, so fix a Rubocop warning about using semicolons.

Added comments to

* app/mailers/application_mailer.rb
* app/models/enumeration.rb
* app/models/phone_number.rb

to fix Rubocop warnings

https://issues.umd.edu/browse/LIBITD-1075