### PR TITLE
LIBITD-1074. Tests now use Selenium and headless Chrome

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,10 +87,11 @@ group :test do
   gem 'minitest-reporters'
   # use the head to get the callback functionality
   gem 'capybara-screenshot'
+  gem 'chromedriver-helper'
   gem 'database_cleaner'
   gem 'mocha'
-  gem 'poltergeist'
   gem 'rack_session_access'
+  gem 'selenium-webdriver'
   gem 'shoulda-context'
   gem 'shoulda-matchers', '>= 3.0.1'
   gem 'test_after_commit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,8 +43,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.5.0)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     airbrussh (1.1.2)
       sshkit (>= 1.6.1, != 1.7.0)
     ansi (1.5.0)
@@ -68,13 +68,13 @@ GEM
     capistrano-rails (1.2.2)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capybara (2.12.0)
+    capybara (2.18.0)
       addressable
-      mime-types (>= 1.16)
+      mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      xpath (~> 2.0)
+      xpath (>= 2.0, < 4.0)
     capybara-screenshot (1.0.14)
       capybara (>= 1.0, < 3)
       launchy
@@ -219,7 +219,7 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
-    public_suffix (2.0.5)
+    public_suffix (3.0.3)
     rack (1.6.10)
     rack-cas (0.15.0)
       addressable (~> 2.3)
@@ -347,8 +347,8 @@ GEM
     will_paginate (3.1.5)
     will_paginate-bootstrap (1.0.1)
       will_paginate (>= 3.0.3)
-    xpath (2.0.0)
-      nokogiri (~> 1.3)
+    xpath (3.1.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,8 @@ GEM
     airbrussh (1.1.2)
       sshkit (>= 1.6.1, != 1.7.0)
     ansi (1.5.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (6.0.4)
     ast (2.4.0)
     binding_of_caller (0.7.2)
@@ -78,8 +80,12 @@ GEM
     capybara-screenshot (1.0.21)
       capybara (>= 1.0, < 4)
       launchy
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     climate_control (0.2.0)
-    cliver (0.3.2)
     cocoon (1.2.9)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
@@ -135,6 +141,7 @@ GEM
       minitest (>= 3.0)
     i18n (0.7.0)
     i18n_data (0.7.0)
+    io-like (0.3.0)
     jbuilder (2.6.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -208,10 +215,6 @@ GEM
     parser (2.5.1.2)
       ast (~> 2.4.0)
     pg (0.19.0)
-    poltergeist (1.13.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.2)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -274,6 +277,7 @@ GEM
       rubocop (>= 0.20.1)
     ruby-progressbar (1.10.0)
     ruby_dep (1.3.1)
+    rubyzip (1.2.1)
     sass (3.4.23)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -284,6 +288,9 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    selenium-webdriver (3.14.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     shellany (0.0.1)
     shoulda-context (1.2.2)
     shoulda-matchers (3.1.1)
@@ -341,9 +348,6 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-    websocket-driver (0.6.5)
-      websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.2)
     will_paginate (3.1.5)
     will_paginate-bootstrap (1.0.1)
       will_paginate (>= 3.0.3)
@@ -358,6 +362,7 @@ DEPENDENCIES
   byebug
   capistrano-rails
   capybara-screenshot
+  chromedriver-helper
   cocoon
   connection_pool
   country_select
@@ -378,7 +383,6 @@ DEPENDENCIES
   mocha
   paperclip (~> 5.3.0)
   pg
-  poltergeist
   pry-rails
   rack-cas
   rack_session_access
@@ -389,6 +393,7 @@ DEPENDENCIES
   ruby_dep (~> 1.3.1)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  selenium-webdriver
   shoulda-context
   shoulda-matchers (>= 3.0.1)
   simple_form

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,8 +75,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
-    capybara-screenshot (1.0.14)
-      capybara (>= 1.0, < 3)
+    capybara-screenshot (1.0.21)
+      capybara (>= 1.0, < 4)
       launchy
     climate_control (0.2.0)
     cliver (0.3.2)

--- a/README.md
+++ b/README.md
@@ -2,24 +2,18 @@
 
 Rails application for processing student applications for Libraries employment
 
-# Student Application Application
-
-This is an application to accept applications from students. 
-
 A student application ( called "Prospect" to avoid confusion ) is submitted via a multi-page form. This
 is managed by serializing the parameters in a session, which are marshalled at each step of the process.
 
-Each step has a view defined in the app/views/prospect which is rendered when the process reaches that step. 
+Each step has a view defined in the app/views/prospect which is rendered when the process reaches that step.
 
-
-## Setup 
+## Setup
 
 Requires:
 
 * Ruby 2.2
 * Bundler
-* [phantomjs](http://phantomjs.org/) - PhantomJS must be installed separately, and the executable directory placed on the PATH.
-
+* [Google Chrome](https://www.google.com/chrome/index.html) (for testing)
 
 To run the application:
 
@@ -38,23 +32,35 @@ You can load test fixtures in by using db:seed:demo rake task
 $ ./bin/rake db:seed:demo
 ```
 
-
 To develop, you can run [Guard](https://github.com/guard/guard) by issuing:
 
 ```
 $ ./bin/bundle exec guard
 ```
 
-Testing uses [Minitest](https://github.com/seattlerb/minitest) and [Capybara](https://github.com/jnicklas/capybara).
-[Poltergeist](https://github.com/teampoltergeist/poltergeist) provides a headless Webkit driver for Capybara, which
-can be used for Feature tests that use lots of Javascript. 
+## Testing Setup
+
+Testing uses [Minitest](https://github.com/seattlerb/minitest),
+[Capybara](https://github.com/jnicklas/capybara) and the Selenium web driver.
+
+Google Chrome and [chromedriver](https://sites.google.com/a/chromium.org/chromedriver/)
+are used to provide a headless browser for testing.
+
+The [chromedriver-helper](https://github.com/flavorjones/chromedriver-helper)
+gem should automatically download and install the latest chromedrive executable
+into ~/.chromedriver.
+
+CSS animations and transitions cause visibility/timing issues when testing in
+a headless browser. When running the tests, they have turned off by the
+"lib/no_animations.rb" file, which is added as Rack middleware in the
+"config/environment/test.rb" file.
 
 ## Production Environment Configuration
 
 Requires:
 
-* Postgres client to be installed (on RedHat, the "postgresql" and 
-"postgresql-devel" packages)
+* Postgres client to be installed (on RedHat, the "postgresql" and
+  "postgresql-devel" packages)
 
 The application uses the "dotenv" gem to configure the production environment.
 The gem expects a ".env" file in the root directory to contain the environment
@@ -76,8 +82,8 @@ $ cd ./student-applications; RAILS_ENV=production ./bin/delayed_job start
 $ cd ./student-applications; RAILS_ENV=production ./bin/delayed_job stop
 ```
 
-There are also a number of Job-related rake tasks that can be invoked 
-These include: 
+There are also a number of Job-related rake tasks that can be invoked
+These include:
 
 ```
 ./bin/rake jobs:clear                                         # Clear the delayed_job queue
@@ -93,13 +99,12 @@ To view the delayed_job queue status, you can visit /delayed_job in the
 application. This requires an admin user to be logged in ( first visit
 /prospects to login. )
 
-
 ### Adding users
 
-You can add users via a rake task: 
+You can add users via a rake task:
 
 ```
-$ ./bin/rake db:add_admin_cas_user[cas_directory_id,full_name]  # Add an admin user
-$ ./bin/rake db:add_cas_user[cas_directory_id,full_name]        # Add a non-admin user
-$ ./bin/rake db:bulk_add_users[csv_file]  # use csv file with full_name, directory_id rows 
+$ ./bin/rake 'db:add_admin_cas_user[cas_directory_id,full_name]'  # Add an admin user
+$ ./bin/rake 'db:add_cas_user[cas_directory_id,full_name]'        # Add a non-admin user
+$ ./bin/rake db:bulk_add_users[csv_file]  # use csv file with full_name, directory_id rows
 ```

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+require 'no_animations'
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -43,4 +45,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.active_job.queue_adapter = :inline
+
+  # Disable CSS animations, as it interferes with Capybara testing
+  config.middleware.use Rack::NoAnimations
 end

--- a/lib/no_animations.rb
+++ b/lib/no_animations.rb
@@ -1,0 +1,55 @@
+# From https://gist.github.com/keithtom/8763169
+module Rack
+  # disable CSS3 and jQuery animations in test mode for speed, consistency and avoiding timing issues.
+  # Usage for Rails:
+  # in config/environments/test.rb
+  # config.middleware.use Rack::NoAnimations
+  class NoAnimations
+    def initialize(app, options = {})
+      @app = app
+    end
+
+    def call(env)
+      @status, @headers, @body = @app.call(env)
+      return [@status, @headers, @body] unless html?
+      response = Rack::Response.new([], @status, @headers)
+
+      @body.each { |fragment| response.write inject(fragment) }
+      @body.close if @body.respond_to?(:close)
+
+      response.finish
+    end
+
+    private
+
+    def html?
+      @headers["Content-Type"] =~ /html/
+    end
+
+    def inject(fragment)
+      disable_animations = <<-EOF
+<script type="text/javascript">(typeof jQuery !== 'undefined') && (jQuery.fx.off = true);</script>
+<style>
+  * {
+     -o-transition: none !important;
+     -moz-transition: none !important;
+     -ms-transition: none !important;
+     -webkit-transition: none !important;
+     transition: none !important;
+     -o-transform: none !important;
+     -moz-transform: none !important;
+     -ms-transform: none !important;
+     -webkit-transform: none !important;
+     transform: none !important;
+     -webkit-animation: none !important;
+     -moz-animation: none !important;
+     -o-animation: none !important;
+     -ms-animation: none !important;
+     animation: none !important;
+  }
+</style>
+      EOF
+      fragment.gsub(%r{</head>}, disable_animations + "</head>")
+    end
+  end
+end

--- a/test/features/admin_disable_test.rb
+++ b/test/features/admin_disable_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 feature 'Should be able to login as admin and disable it temporarly' do
   scenario 'login as admin, look around, then test the disable', js: true do
-    page.driver.resize_window(2048, 2048)
+    page.current_window.resize_to(2048, 2048)
     User.create(cas_directory_id: 'admin', name: 'admin', admin: true)
     visit prospects_path
     # Visiting prospects_path should redirect to CAS

--- a/test/features/admin_edit_test.rb
+++ b/test/features/admin_edit_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 feature 'Admins can edit submitted applications' do
   scenario 'login as admin & edit submitted application', js: true do
-    page.driver.resize_window(2048, 2048)
+    page.current_window.resize_to(2048, 2048)
 
     User.create(cas_directory_id: 'editor', name: 'editor', admin: true)
     visit prospects_path

--- a/test/features/availability_test.rb
+++ b/test/features/availability_test.rb
@@ -34,7 +34,7 @@ feature 'Add some Available Times' do
 
     # lets click the 5 tds related to that checkbox
     day_times.each_with_index do |dt, i|
-      find(:css, "input[value='#{dt}']", visible: false).first(:xpath, './/../..').trigger(:click)
+      find(:css, "input[value='#{dt}']", visible: false).first(:xpath, './/../..').click
     end
 
     assert_equal day_times.length, find_all(:css, 'input[type=checkbox]:checked', visible: false).length
@@ -80,7 +80,7 @@ feature 'Add some Available Times' do
 
     # lets click the 5 tds related to that checkbox
     day_times.each do |dt|
-      find(:css, "input[value='#{dt}']", visible: false).first(:xpath, './/../..').trigger(:click)
+      find(:css, "input[value='#{dt}']", visible: false).first(:xpath, './/../..').click
     end
 
     # but let's put the total times higher..

--- a/test/features/comment_confirmation_test.rb
+++ b/test/features/comment_confirmation_test.rb
@@ -6,7 +6,7 @@ feature 'Comment Confirmation page' do
     fixture = prospects(:all_valid)
     all_valid = fixture.attributes
     all_valid[:enumeration_ids] = fixture.enumerations.map(&:id)
-    all_valid.reject! { |a| %w(id created_at updated_at).include? a } 
+    all_valid.reject! { |a| %w(id created_at updated_at).include? a }
 
     all_valid[:directory_id] = SecureRandom.hex
     all_valid[:semester] = "Fall 2017"
@@ -23,9 +23,21 @@ feature 'Comment Confirmation page' do
     assert page.has_content?('Fall 2017')
 
     [ 'Applicant Info', 'Contact Info', 'Work Experience', 'Skills', 'Availability', 'Resume'].each do |step|
-      
+
       click_link("Change #{step}")
-      assert page.has_content?(step)
+
+      # Applicant Info step does not have a specific H2 page header, so we need
+      # to look for something different, otherwise just use "step"
+      if (step == 'Applicant Info')
+        within('h4') do
+          assert page.has_content?('Please enter your Student ID')
+        end
+      else
+        within('h2') do
+          assert page.has_content?(step)
+        end
+      end
+
       # cycle back to the confirmation page
       10.times do
         click_button 'Continue'

--- a/test/features/configuration_test.rb
+++ b/test/features/configuration_test.rb
@@ -2,93 +2,93 @@ require 'test_helper'
 
 
 feature 'Should be able to configuration that application' do
-  
+
   scenario 'admin should be able to promote and unpromote skills', js: true do
-    page.driver.resize_window(2048, 2048)
+    page.current_window.resize_to(2048, 2048)
     User.create(cas_directory_id: 'admin', name: 'admin', admin: true)
     visit configuration_path
     # Visiting prospects_path should redirect to CAS
     fill_in 'username', with: 'admin'
     fill_in 'password', with: 'any password'
     click_button 'Login'
-    
+
     click_link 'SKILLS'
 
     skill = Skill.promoted.first
-    assert skill.promoted? 
+    assert skill.promoted?
     assert page.has_content?(skill.name)
-   
 
-    find(:css, "#skill_#{skill.id} .toggle:not(.off)").trigger(:click)
+
+    find(:css, "#skill_#{skill.id} .toggle:not(.off)").click
     page.must_have_selector  "#skill_#{skill.id} .toggle.off"
-    sleep 1 
+    sleep 1
 
-    refute skill.reload.promoted? 
-    find(:css, "#skill_#{skill.id} .toggle").trigger(:click)
+    refute skill.reload.promoted?
+    find(:css, "#skill_#{skill.id} .toggle").click
     page.must_have_selector  "#skill_#{skill.id} .toggle:not(.off)"
-    sleep 1 
-    assert skill.reload.promoted? 
+    sleep 1
+    assert skill.reload.promoted?
   end
 
   scenario 'admin should be able to activate and unactivate enumeration', js: true do
-    page.driver.resize_window(2048, 2048)
+    page.current_window.resize_to(2048, 2048)
     User.create(cas_directory_id: 'admin', name: 'admin', admin: true)
     visit configuration_path
     # Visiting prospects_path should redirect to CAS
     fill_in 'username', with: 'admin'
     fill_in 'password', with: 'any password'
     click_button 'Login'
-  
+
     list = Enumeration.lists.keys.first.pluralize
     click_link list.humanize.upcase
 
     enum = Enumeration.send("active_#{list}".intern).first
-    assert enum.active? 
+    assert enum.active?
     assert page.has_content?(enum.value)
 
 
-    find(:css, "#enumeration_#{enum.id} .toggle:not(.off)").trigger(:click)
+    find(:css, "#enumeration_#{enum.id} .toggle:not(.off)").click
     page.must_have_selector  "#enumeration_#{enum.id} .toggle.off"
-    sleep(1) 
-    refute enum.reload.active? 
-    find(:css, "#enumeration_#{enum.id} .toggle").trigger(:click)
+    sleep(1)
+    refute enum.reload.active?
+    find(:css, "#enumeration_#{enum.id} .toggle").click
     page.must_have_selector  "#enumeration_#{enum.id} .toggle:not(.off)"
-    sleep(1) 
-    assert enum.reload.active? 
+    sleep(1)
+    assert enum.reload.active?
   end
-  
+
   scenario 'admin should be able to create enumeration', js: true do
-    page.driver.resize_window(2048, 2048)
+    page.current_window.resize_to(2048, 2048)
     User.create(cas_directory_id: 'admin', name: 'admin', admin: true)
     visit configuration_path
     # Visiting prospects_path should redirect to CAS
     fill_in 'username', with: 'admin'
     fill_in 'password', with: 'any password'
     click_button 'Login'
-    
+
     list = Enumeration.lists.keys.first
     click_link list.pluralize.humanize.upcase
-    assert page.must_have_selector "#enumeration-#{list}.collapse.in" 
-    
+    assert page.must_have_selector "#enumeration-#{list}.collapse.in"
+
     assert_difference( 'Enumeration.count' ) do
       find(:css, "input#enumeration_#{list}_value").send_keys "phd", :enter
       assert page.has_content?("phd")
     end
-  
+
   end
-  
+
   scenario 'admin should be able to create enumerat', js: true do
-    page.driver.resize_window(2048, 2048)
+    page.current_window.resize_to(2048, 2048)
     User.create(cas_directory_id: 'admin', name: 'admin', admin: true)
     visit configuration_path
     # Visiting prospects_path should redirect to CAS
     fill_in 'username', with: 'admin'
     fill_in 'password', with: 'any password'
     click_button 'Login'
-    
+
     click_link 'SKILLS'
-    assert page.must_have_selector "#skills.collapse.in" 
-    
+    assert page.must_have_selector "#skills.collapse.in"
+
     assert_difference( 'Skill.count' ) do
       find(:css, "input#new_skill_name").send_keys "programming", :enter
       assert page.has_content?("programming")

--- a/test/features/filter_available_hours_test.rb
+++ b/test/features/filter_available_hours_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 feature 'Should be able filter prospects on available hours per week' do
   scenario 'login as user & filter', js: true do
-    page.driver.resize_window(2048, 2048)
+    page.current_window.resize_to(2048, 2048)
 
     User.create(cas_directory_id: 'filterer', name: 'filterer', admin: false)
     visit prospects_path

--- a/test/features/filter_available_times_test.rb
+++ b/test/features/filter_available_times_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 # rubocop:disable Metric/BlockLength
 feature 'Should be able filter prospects on available times' do
   scenario 'login as user & filter', js: true do
-    page.driver.resize_window(2048, 2048)
+    page.current_window.resize_to(2048, 2048)
 
     User.create(cas_directory_id: 'filterer', name: 'filterer', admin: false)
     visit prospects_path
@@ -17,44 +17,44 @@ feature 'Should be able filter prospects on available times' do
     Prospect.find_by(first_name: 'Alvin').update_attribute(:day_times, ['0-8', '0-9'])
     Prospect.find_by(first_name: 'Rolling').update_attribute(:day_times, ['1-8', '1-9', '1-10'])
     # rubocop:ensable Rails/SkipsModelValidations
-    
+
     students = Prospect.all.group_by(&:first_name).map { |k,v| [k, v.first] }.to_h
 
     # We should have all of our students present
     # We should have all of our students present
-    page.must_have_selector("#prospect_#{ students["Betty"].id  }") 
-    page.must_have_selector("#prospect_#{ students["Alvin"].id  }") 
-    page.must_have_selector("#prospect_#{ students["Rolling"].id  }") 
+    page.must_have_selector("#prospect_#{ students["Betty"].id  }")
+    page.must_have_selector("#prospect_#{ students["Alvin"].id  }")
+    page.must_have_selector("#prospect_#{ students["Rolling"].id  }")
 
     find('#filter-prospects').click
-    assert page.find( "#filter-modal" ).visible? 
+    assert page.find( "#filter-modal" ).visible?
 
-    find('#available_time-0-9').trigger(:click)
+    find('#available_time-0-9').click
     assert find("input#available_time-0-9")["checked"]
-    
-    find('#submit-filter').trigger(:click)
-    page.wont_have_selector( "#filter-modal" ) 
-    
+
+    find('#submit-filter').click
+    page.wont_have_selector( "#filter-modal" )
+
     # check for prospects with the first time; should be two out of three
-    page.must_have_selector("#prospect_#{ students["Betty"].id  }") 
-    page.must_have_selector("#prospect_#{ students["Alvin"].id  }") 
-    page.wont_have_selector("#prospect_#{ students["Rolling"].id  }") 
+    page.must_have_selector("#prospect_#{ students["Betty"].id  }")
+    page.must_have_selector("#prospect_#{ students["Alvin"].id  }")
+    page.wont_have_selector("#prospect_#{ students["Rolling"].id  }")
 
     find('#filter-prospects').click
-    page.must_have_selector( "#filter-modal" ) 
+    page.must_have_selector( "#filter-modal" )
 
     # check for prospects with both times; should only be one
-    find('#available_time-0-10').trigger(:click)
+    find('#available_time-0-10').click
     assert find("input#available_time-0-9")["checked"]
     assert find("input#available_time-0-10")["checked"]
     assert_equal 2, all('.available_time').select(&:checked?).length
-    
+
     find('#submit-filter').click
-    page.wont_have_selector( "#filter-modal" ) 
-    
-    page.must_have_selector("#prospect_#{ students["Betty"].id  }") 
-    page.wont_have_selector("#prospect_#{ students["Rolling"].id  }") 
-    page.wont_have_selector("#prospect_#{ students["Alvin"].id  }") 
+    page.wont_have_selector( "#filter-modal" )
+
+    page.must_have_selector("#prospect_#{ students["Betty"].id  }")
+    page.wont_have_selector("#prospect_#{ students["Rolling"].id  }")
+    page.wont_have_selector("#prospect_#{ students["Alvin"].id  }")
 
   end
 end

--- a/test/features/filter_class_status_test.rb
+++ b/test/features/filter_class_status_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 feature 'Should be able filter prospects on class status' do
   scenario 'login as user & filter', js: true do
-    page.driver.resize_window(2048, 9999)
+    page.current_window.resize_to(2048, 9999)
 
     undergrad = Enumeration.find_by( value: "Undergraduate" ).id
     User.create(cas_directory_id: 'filterer', name: 'filterer', admin: false)
-    
+
     students = Prospect.all.group_by(&:first_name).map { |k,v| [k, v.first] }.to_h
 
     visit prospects_path
@@ -15,23 +15,23 @@ feature 'Should be able filter prospects on class status' do
     click_button 'Login'
 
     # We should have all of our students present
-    page.must_have_selector("#prospect_#{ students["Betty"].id  }") 
-    page.must_have_selector("#prospect_#{ students["Alvin"].id  }") 
-    page.must_have_selector("#prospect_#{ students["Rolling"].id  }") 
+    page.must_have_selector("#prospect_#{ students["Betty"].id  }")
+    page.must_have_selector("#prospect_#{ students["Alvin"].id  }")
+    page.must_have_selector("#prospect_#{ students["Rolling"].id  }")
 
     find("#filter-prospects").click
-    assert page.find( "#filter-modal" ).visible? 
-  
-    # we tweak the slider...
-    find("input#class_status_#{undergrad}").trigger(:click)
-    assert find("input#class_status_#{undergrad}")["checked"]
-    
-    find("#submit-filter").trigger(:click)
-    page.must_have_selector( "#filter-modal", visible: false ) 
+    assert page.find( "#filter-modal" ).visible?
 
-    # only alvin is an undergrad 
-    page.wont_have_selector("#prospect_#{ students["Betty"].id  }") 
-    page.wont_have_selector("#prospect_#{ students["Rolling"].id  }") 
-    page.must_have_selector("#prospect_#{ students["Alvin"].id  }") 
+    # we tweak the slider...
+    find("input#class_status_#{undergrad}").click
+    assert find("input#class_status_#{undergrad}")["checked"]
+
+    find("#submit-filter").click
+    page.must_have_selector( "#filter-modal", visible: false )
+
+    # only alvin is an undergrad
+    page.wont_have_selector("#prospect_#{ students["Betty"].id  }")
+    page.wont_have_selector("#prospect_#{ students["Rolling"].id  }")
+    page.must_have_selector("#prospect_#{ students["Alvin"].id  }")
   end
 end

--- a/test/features/filter_directory_id_test.rb
+++ b/test/features/filter_directory_id_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 feature 'Should be able filter prospects on class status' do
   scenario 'login as user & filter', js: true do
-    page.driver.resize_window(2048, 9999)
+    page.current_window.resize_to(2048, 9999)
 
     undergrad = Enumeration.find_by( value: "Undergraduate" ).id
     User.create(cas_directory_id: 'filterer', name: 'filterer', admin: false)
-    
+
     students = Prospect.all.group_by(&:first_name).map { |k,v| [k, v.first] }.to_h
 
     visit prospects_path
@@ -15,22 +15,22 @@ feature 'Should be able filter prospects on class status' do
     click_button 'Login'
 
     # We should have all of our students present
-    page.must_have_selector("#prospect_#{ students["Betty"].id  }") 
-    page.must_have_selector("#prospect_#{ students["Alvin"].id  }") 
-    page.must_have_selector("#prospect_#{ students["Rolling"].id  }") 
+    page.must_have_selector("#prospect_#{ students["Betty"].id  }")
+    page.must_have_selector("#prospect_#{ students["Alvin"].id  }")
+    page.must_have_selector("#prospect_#{ students["Rolling"].id  }")
 
     find("#filter-prospects").click
-    assert page.find( "#filter-modal" ).visible? 
-  
+    assert page.find( "#filter-modal" ).visible?
+
     # we tweak the slider...
     fill_in "text_search_directory_id", with: students["Alvin"].directory_id
-    
-    find("#submit-filter").trigger(:click)
-    page.must_have_selector( "#filter-modal", visible: false ) 
 
-    # only alvin is an undergrad 
-    page.wont_have_selector("#prospect_#{ students["Betty"].id  }") 
-    page.wont_have_selector("#prospect_#{ students["Rolling"].id  }") 
-    page.must_have_selector("#prospect_#{ students["Alvin"].id  }") 
+    find("#submit-filter").click
+    page.must_have_selector( "#filter-modal", visible: false )
+
+    # only alvin is an undergrad
+    page.wont_have_selector("#prospect_#{ students["Betty"].id  }")
+    page.wont_have_selector("#prospect_#{ students["Rolling"].id  }")
+    page.must_have_selector("#prospect_#{ students["Alvin"].id  }")
   end
 end

--- a/test/features/prospect_deactivate_test.rb
+++ b/test/features/prospect_deactivate_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 feature 'Should be able to login as admin and deactivate applications' do
   scenario 'login as admin and deactivate applications', js: true do
-    page.driver.resize_window(2048, 2048)
+    page.current_window.resize_to(2048, 2048)
     User.create(cas_directory_id: 'admin', name: 'admin', admin: true)
     visit prospects_path
     # Visiting prospects_path should redirect to CAS

--- a/test/features/reset_form_test.rb
+++ b/test/features/reset_form_test.rb
@@ -2,10 +2,10 @@ require 'test_helper'
 
 feature 'Verify "Reset" button functionality' do
   scenario 'put some basic information into the first step and hit "Reset"', js: true do
-    page.driver.resize_window(2048, 2048)
+    page.current_window.resize_to(2048, 2048)
     visit root_path
     click_link 'Apply!'
-    
+
     fill_in('Directory', with: 'myIdentifier')
     choose(Enumeration.active_semesters.first.value)
     click_button 'Continue'
@@ -28,6 +28,6 @@ feature 'Verify "Reset" button functionality' do
     # fields.
     click_link 'Apply!'
     assert page.has_field?('Directory', with: '')
-  
+
   end
 end

--- a/test/features/resume_upload_test.rb
+++ b/test/features/resume_upload_test.rb
@@ -25,7 +25,7 @@ feature 'Upload a resume' do
       end
 
       assert page.has_content?('Resume')
-      page.attach_file('resume_file', 'test/fixtures/resume.pdf', visible: false)
+      page.attach_file('resume_file', File.absolute_path('test/fixtures/resume.pdf'), visible: false)
 
       find("input[name='uploadResume']").click
 
@@ -70,9 +70,13 @@ feature 'Upload a resume' do
       break if page.has_content?('Resume')
     end
     assert page.has_content?('Resume')
-    page.attach_file('resume_file', 'test/fixtures/resume.notpdf', visible: false)
+    page.attach_file('resume_file', File.absolute_path('test/fixtures/resume.notpdf'), visible: false)
 
     find("input[name='uploadResume']").click
+
+    # Dismiss dialog indicating file must be a PDF
+    alert = page.driver.browser.switch_to.alert
+    alert.dismiss
 
     refute_selector "input[value='Success!']"
 

--- a/test/features/sort_preserves_filter_test.rb
+++ b/test/features/sort_preserves_filter_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 feature 'Should preserve filter query when sorting' do
   scenario 'login as user & filter & sort', js: true do
-    page.driver.resize_window(2048, 2048)
+    page.current_window.resize_to(2048, 2048)
 
     User.create(cas_directory_id: 'filterer', name: 'filterer', admin: false)
     visit prospects_path

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,7 +20,7 @@ require 'minitest/rails/capybara'
 require 'minitest/reporters'
 
 # add  Minitest::Reporters::SpecReporter.new to first param if you want to see
-# what's running so damn slow.
+# what's running so slow.
 Minitest::Reporters.use!(
   # Minitest::Reporters::SpecReporter.new,
   Minitest::Reporters::ProgressReporter.new,
@@ -28,19 +28,15 @@ Minitest::Reporters.use!(
   Minitest.backtrace_filter
 )
 
-# Capybara and poltergeist integration
+# Capybara integration
 require 'capybara/rails'
-require 'capybara/poltergeist'
 require 'capybara-screenshot/minitest'
 
-# for debugging
-# https://github.com/teampoltergeist/poltergeist#remote-debugging-experimental
-# Capybara.register_driver :poltergeist_debug do |app|
-#  Capybara::Poltergeist::Driver.new(app, :inspector => true)
-# end
-# Capybara.javascript_driver = :poltergeist_debug
+# To see test in browser,
+# use ":selenium_chrome" instead of ":selenium_chrome_headless"
+Capybara.default_driver = :selenium_chrome_headless
+Capybara.javascript_driver = :selenium_chrome_headless
 
-Capybara.javascript_driver = :poltergeist
 require 'rack_session_access/capybara'
 
 DatabaseCleaner.strategy = :truncation, { only: %w(prospects) }
@@ -66,7 +62,7 @@ class ActiveSupport::TestCase
     fixture.directory_id = SecureRandom.hex
     fixture
   end
-  
+
 
 end
 
@@ -93,6 +89,7 @@ ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection
 
 def drag_until(locator, options = {}, &block)
   slider = find(locator)
-  slider.native.drag_by(options[:by], 0) until block.call(slider['aria-valuenow'].to_i)
+  event_input = slider.native
+  page.driver.browser.action.click_and_hold(event_input).move_by(options[:by],0).release.perform until block.call(slider['aria-valuenow'].to_i)
   slider
 end


### PR DESCRIPTION
Modified the test infrastructure and tests to use Selenium and
headless Chrome instead of poltergeist/phantomjs.

Added "selenium-webdriver" gem to enable Capybara to use Selenium.

Added "chromedriver-helper" gem to download and use chromedriver if
it is not present on the system.

Added "lib/animations.rb" as Rack middleware to turn off CSS
animations/transitions which were causing timing/visibility issues
when running in Selenium.

Updated tests relying on the Poltergeist API to use the Webdriver API
and other quirks of the Poltergeist/phantomjs setup, including the
following:

* Updated "drag_until" method in test/test_helper.rb
* Replaced "trigger(:click)" with just "click"
* Added "no_animations.rb" Rack middleware turn off CSS animations when
  testing
* Set absolute path when referencing files
* Fixed text verification in comment_confirmation_test.rb

https://issues.umd.edu/browse/LIBITD-1074