### PR TITLE
LIBITD-1219. Modified filter to use AND between selection criteria

### DIFF
--- a/app/controllers/concerns/querying_prospects.rb
+++ b/app/controllers/concerns/querying_prospects.rb
@@ -96,6 +96,18 @@ module QueryingProspects
       params[:available_time] ? { 'prospects.id' => AvailableTime.find_by_sql(day_times_sql).map(&:prospect_id) } : {}
     end
 
+    # Returns a query for the given enumeration type (as represented by the
+    # method name on the Enumeration object)
+    def enumeration_type_search_statement(enumeration_type)
+      all_type_ids = Enumeration.send(enumeration_type).map { |s| s.id.to_s }
+
+      # Get the ids in the params that are in the enumeration type
+      ids_for_search = all_type_ids & params[:search][:enumerations]
+
+      return if ids_for_search.empty?
+      Arel::Table.new(Prospect.reflect_on_association('enumerations').table_name)[:id].in(ids_for_search)
+    end
+
     def search_statement
       query = params[:search].each_with_object([]) do |(k, val), memo|
         next if val.empty?

--- a/app/views/prospects/_filter_modal.html.erb
+++ b/app/views/prospects/_filter_modal.html.erb
@@ -6,97 +6,97 @@
         <h4 class="modal-title">Filter Applications</h4>
       </div>
       <div class="modal-body">
-        <div class="container"> 
-        <%= form_tag prospects_path, method: 'get', id: 'filter-prospects-form' do %> 
+        <div class="container">
+        <%= form_tag prospects_path, method: 'get', id: 'filter-prospects-form' do %>
             <div class="row">
-              <h4>Contact Information</h4> 
-              <div class="col-md-2"> 
-                <%= label_tag "text_search[last_name]", "Last Name" %> 
-                <%= text_field_tag "text_search[last_name]", params[:text_search][:last_name] || "", placeholder: "Use % for wildcard" %> 
-              </div>   
-              <div class="col-md-2"> 
-                <%= label_tag "text_search[first_name]", "First Name" %> 
-                <%= text_field_tag "text_search[first_name]", params[:text_search][:first_name] || "", placeholder: "Use % for wildcard" %> 
-              </div>   
-              <div class="col-md-2"> 
-                <%= label_tag "text_search[directory_id]", "Directory ID" %> 
-                <%= text_field_tag "text_search[directory_id]", params[:text_search][:directory_id] || "", placeholder: "Use % for wildcard" %> 
-              </div>   
+              <h4>Contact Information</h4>
+              <div class="col-md-2">
+                <%= label_tag "text_search[last_name]", "Last Name" %>
+                <%= text_field_tag "text_search[last_name]", params[:text_search][:last_name] || "", placeholder: "Use % for wildcard" %>
+              </div>
+              <div class="col-md-2">
+                <%= label_tag "text_search[first_name]", "First Name" %>
+                <%= text_field_tag "text_search[first_name]", params[:text_search][:first_name] || "", placeholder: "Use % for wildcard" %>
+              </div>
+              <div class="col-md-2">
+                <%= label_tag "text_search[directory_id]", "Directory ID" %>
+                <%= text_field_tag "text_search[directory_id]", params[:text_search][:directory_id] || "", placeholder: "Use % for wildcard" %>
+              </div>
             </div> <!-- contact info row -->
-            
+
             <div class="row">
-                <h4>Available Hours</h4> 
-                <div class="col-md-8 availability-select"> 
-                  <b>0</b><input id="available-hours-selector" type="text" class="span2" value="" data-slider-min="0" 
+                <h4>Available Hours</h4>
+                <div class="col-md-8 availability-select">
+                  <b>0</b><input id="available-hours-selector" type="text" class="span2" value="" data-slider-min="0"
                   data-slider-max="50" data-slider-step="1"
                   data-slider-value="[<%= params[:available_hours_per_week_min] || 0 %>,<%= params[:available_hours_per_week_max] || 50 %>]"/><b>50</b>
-                 <%= hidden_field_tag( "available_hours_per_week_min", params[:available_hours_per_week_min] || 0, { id: 'availability-min' } ) %> 
-                 <%= hidden_field_tag( "available_hours_per_week_max", params[:available_hours_per_week_max] || 50,{ id: 'availability-max' }) %> 
+                 <%= hidden_field_tag( "available_hours_per_week_min", params[:available_hours_per_week_min] || 0, { id: 'availability-min' } ) %>
+                 <%= hidden_field_tag( "available_hours_per_week_max", params[:available_hours_per_week_max] || 50,{ id: 'availability-max' }) %>
                 </div>
             </div>
-            
+
             <div class="row">
-                <h4>Semester</h4> 
+                <h4>Semester</h4>
                 <% Enumeration.active_semesters.in_groups_of( 2 ) do |batch| %>
                   <div class="row">
-                    <% batch.each do |sem| %> 
+                    <% batch.each do |sem| %>
                       <div class="col-md-4">
-                        <% unless sem.nil? %> 
-                          <%= check_box_tag( "search[enumerations][]", sem.id, params[:search][:enumerations].include?(sem.id.to_s), { :multiple => true, id: "semeser_#{sem.id}" } )  %>
+                        <% unless sem.nil? %>
+                          <%= check_box_tag( "search[enumerations][]", sem.id, params[:search][:enumerations].include?(sem.id.to_s), { :multiple => true, id: "semester_#{sem.id}" } )  %>
                           <%= label_tag(  "search[enumerations][id]",  sem.value )  %>
-                        <% end %>   
+                        <% end %>
                       </div>
-                    <% end %> 
+                    <% end %>
                   </div>
-                <% end %>   
+                <% end %>
             </div>
-            
+
             <div class="row">
-                <h4>Class Status</h4> 
+                <h4>Class Status</h4>
                 <% Enumeration.active_class_statuses.in_groups_of( 2 ) do |batch| %>
                   <div class="row">
-                    <% batch.each do |sem| %> 
+                    <% batch.each do |sem| %>
                       <div class="col-md-4">
-                        <% unless sem.nil? %> 
+                        <% unless sem.nil? %>
                           <%= check_box_tag( "search[enumerations][]", sem.id, params[:search][:enumerations].include?(sem.id.to_s), { :multiple => true, id: "class_status_#{sem.id}" }  )  %>
                           <%= label_tag(  "search[enumerations][id]",  sem.value )  %>
-                        <% end %>   
+                        <% end %>
                       </div>
-                    <% end %> 
+                    <% end %>
                   </div>
-                <% end %>   
+                <% end %>
             </div>
-            
+
             <div class="row">
-                <h4>Skills</h4> 
+                <h4>Skills</h4>
                 <% Skill.promoted.in_groups_of( 2 ) do |batch| %>
                   <div class="row">
-                    <% batch.each do |sk| %> 
+                    <% batch.each do |sk| %>
                       <div class="col-md-4">
-                        <% unless sk.nil? %> 
+                        <% unless sk.nil? %>
                           <%= check_box_tag( "search[skills][]", sk.id, params[:search][:skills].include?(sk.id.to_s), { :multiple => true }  )  %>
                           <%= label_tag(  "search[skills][id]",  sk.name )  %>
-                        <% end %>   
+                        <% end %>
                       </div>
-                    <% end %> 
+                    <% end %>
                   </div>
-                <% end %>   
+                <% end %>
             </div>
-            
+
             <div class="row">
-                <h4>Preferred Libraries</h4> 
+                <h4>Preferred Libraries</h4>
                 <% Enumeration.active_libraries.in_groups_of( 2 ) do |batch| %>
                   <div class="row">
-                    <% batch.each do |lib| %> 
+                    <% batch.each do |lib| %>
                       <div class="col-md-4">
-                        <% unless lib.nil? %> 
+                        <% unless lib.nil? %>
                           <%= check_box_tag( "search[enumerations][]", lib.id, params[:search][:enumerations].include?(lib.id.to_s), { :multiple => true }  )  %>
                           <%= label_tag(  "search[enumerations][id]",  lib.value )  %>
-                        <% end %>   
+                        <% end %>
                       </div>
-                    <% end %> 
+                    <% end %>
                   </div>
-                <% end %>   
+                <% end %>
             </div>
 
             <div class="row">
@@ -124,14 +124,14 @@
               <% end %>
             </div>
 
-          
+
         <% end %> <!-- form tag -->
-        </div> <!-- container --> 
+        </div> <!-- container -->
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
         <button type="button" id="submit-filter" class="btn btn-success" >Filter</button>
-      </div>  
+      </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->

--- a/test/controllers/prospects_controller_test.rb
+++ b/test/controllers/prospects_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ProspectsControllerTest < ActionController::TestCase
 
   test 'should allow authed users to deactivate a submitted application' do
-    prospect = prospects(:all_valid) 
+    prospect = prospects(:all_valid)
     refute prospect.suppressed?
     session[:cas] = { user: "admin" }
     post :deactivate, format: :json,  ids: [ prospect.id ]
@@ -17,11 +17,11 @@ class ProspectsControllerTest < ActionController::TestCase
 
     class InvalidShoeSize <  ActiveRecord::ActiveRecordError; end
 
-    Rails.logger.expects(:error).with(anything).at_least_once 
-    Rails.logger.expects(:error).with("Uh-Oh!").at_least_once 
-    Prospect.any_instance.stubs(:save).raises( InvalidShoeSize, "Uh-Oh!" ) 
-    
-   
+    Rails.logger.expects(:error).with(anything).at_least_once
+    Rails.logger.expects(:error).with("Uh-Oh!").at_least_once
+    Prospect.any_instance.stubs(:save).raises( InvalidShoeSize, "Uh-Oh!" )
+
+
     fixture = dup_fixture
     all_valid = JSON.parse(fixture.to_json).to_hash
     assert fixture.all_valid?
@@ -33,15 +33,154 @@ class ProspectsControllerTest < ActionController::TestCase
     all_valid['available_times_attributes'] = []
     all_valid['available_hours_per_week'] = 0
     all_valid['phone_numbers_attributes'] = [ JSON.parse( phone_numbers(:all_valid_dummy).to_json).to_hash.reject { |a| a == 'id' }]
-    
+
     session[:cas] = { user: "admin" }
     session[:prospect_step] = fixture.current_step
-    
+
     refute_difference( 'Prospect.count' ) do
       post :create,  { prospect: all_valid }
-    end 
-    
+    end
+
     assert flash[:error] == "We're sorry, but something has gone wrong. Please try again."
 
+  end
+
+  test 'Semester field should be filterable' do
+    session[:cas] = { user: "admin" }
+    spring_2018 = enumerations(:spring_2018)
+    search_criteria = [spring_2018.id]
+    get :index, { search: { enumerations: search_criteria } }
+
+    all_request_ids = assigns(:all_results)
+
+    # Make sure we filtered one or more records
+    assert all_request_ids.count < Prospect.count
+
+    all_request_ids.each do |id|
+      prospect = Prospect.find(id)
+      assert_equal spring_2018, prospect.semester,
+                    "Incorrect semester for #{prospect.id} - #{prospect.last_name}, #{prospect.first_name}"
+    end
+  end
+
+  test 'Class Status field should be filterable' do
+    session[:cas] = { user: "admin" }
+    undergraduate = enumerations(:undergraduate)
+    search_criteria = [undergraduate.id]
+    get :index, { search: { enumerations: search_criteria } }
+
+    all_request_ids = assigns(:all_results)
+
+    # Make sure we filtered one or more records
+    assert all_request_ids.count < Prospect.count
+
+    all_request_ids.each do |id|
+      prospect = Prospect.find(id)
+      assert_equal undergraduate, prospect.class_status,
+                   "Incorrect class status for #{prospect.id} - #{prospect.last_name}, #{prospect.first_name}"
+    end
+  end
+
+  test 'Preferred Library field should be filterable' do
+    session[:cas] = { user: "admin" }
+    art_library = enumerations(:art_library)
+    search_criteria = [art_library.id]
+    get :index, { search: { enumerations: search_criteria } }
+
+    all_request_ids = assigns(:all_results)
+
+    # Make sure we filtered one or more records
+    assert all_request_ids.count < Prospect.count
+
+    all_request_ids.each do |id|
+      prospect = Prospect.find(id)
+      assert prospect.libraries.include?(art_library),
+            "Incorrect preferred libraries for #{prospect.id} - #{prospect.last_name}, #{prospect.first_name} - libraries: #{prospect.libraries}"
+    end
+  end
+
+  test 'Filtering on multiple Class Status fields should be ORed' do
+    session[:cas] = { user: "admin" }
+    undergraduate = enumerations(:undergraduate)
+    graduate = enumerations(:graduate)
+    search_criteria = [undergraduate.id, graduate.id]
+    get :index, { search: { enumerations: search_criteria } }
+
+    all_request_ids = assigns(:all_results)
+
+    # Should get all the records (since Class Status is required, and there
+    # are only two options)
+    assert all_request_ids.count == Prospect.count
+  end
+
+  test 'Filtering on multiple Preferred Library field should be ORed' do
+    session[:cas] = { user: "admin" }
+    art_library = enumerations(:art_library)
+    engineering_library = enumerations(:engineering_library)
+    search_criteria = [art_library, engineering_library.id]
+    get :index, { search: { enumerations: search_criteria } }
+
+    all_request_ids = assigns(:all_results)
+
+    # Make sure we filtered one or more records
+    assert all_request_ids.count < Prospect.count
+
+    all_request_ids.each do |id|
+      prospect = Prospect.find(id)
+      libraries = prospect.libraries
+      assert (libraries.include?(art_library) || libraries.include?(engineering_library)),
+             "Incorrect preferred libraries for #{prospect.id} - #{prospect.last_name}, #{prospect.first_name} - libraries: #{prospect.libraries}"
+    end
+  end
+
+  test 'Class Status and Semester filters should be ANDed together' do
+    session[:cas] = { user: "admin" }
+
+    undergraduate = enumerations(:undergraduate)
+    spring_2018 = enumerations(:spring_2018)
+    search_criteria = [undergraduate.id, spring_2018.id]
+
+    get :index, { search: { enumerations: search_criteria } }
+
+    all_request_ids = assigns(:all_results)
+
+    # Make sure we filtered one or more records
+    assert all_request_ids.count < Prospect.count
+    assert all_request_ids.count > 0
+
+    all_request_ids.each do |id|
+      prospect = Prospect.find(id)
+      assert_equal undergraduate, prospect.class_status,
+                   "Incorrect class status for #{prospect.id} - #{prospect.last_name}, #{prospect.first_name}"
+      assert_equal spring_2018, prospect.semester,
+                   "Incorrect semester for #{prospect.id} - #{prospect.last_name}, #{prospect.first_name}"
+    end
+  end
+
+  test 'Class Status, Semester and Preferred Libraries filters should be ANDed together' do
+    session[:cas] = { user: "admin" }
+
+    undergraduate = enumerations(:undergraduate)
+    spring_2018 = enumerations(:spring_2018)
+    engineering_library = enumerations(:engineering_library)
+    search_criteria = [undergraduate.id, spring_2018.id, engineering_library.id]
+
+    get :index, { search: { enumerations: search_criteria } }
+
+    all_request_ids = assigns(:all_results)
+
+    # Make sure we filtered one or more records
+    assert all_request_ids.count < Prospect.count
+    assert all_request_ids.count > 0
+
+    all_request_ids.each do |id|
+      prospect = Prospect.find(id)
+      assert_equal undergraduate, prospect.class_status,
+                   "Incorrect class status for #{prospect.id} - #{prospect.last_name}, #{prospect.first_name}"
+      assert_equal spring_2018, prospect.semester,
+                   "Incorrect semester for #{prospect.id} - #{prospect.last_name}, #{prospect.first_name}"
+      assert_contains prospect.libraries, engineering_library
+                   "Incorrect library for #{prospect.id} - #{prospect.last_name}, #{prospect.first_name}"
+    end
   end
 end

--- a/test/fixtures/enumerations.yml
+++ b/test/fixtures/enumerations.yml
@@ -1,52 +1,59 @@
+# Class Status
 undergraduate:
   value: Undergraduate
   list: 0
   position: 0
-  prospects: contact_info
 graduate:
   value: Graduate
-  list: 0 
+  list: 0
   position: 1
-  prospects: homeless, all_valid
-sixteen_dec:
+
+# Expected Graduation
+december_2016:
   value: 2016 Dec
-  list: 1 
+  list: 1
   position: 0
-seventeen_may:
+may_2017:
   value: 2017 May
-  list: 1 
+  list: 1
   position: 1
-  prospects: homeless, contact_info
-seventeen_dec:
+december_2017:
   value: 2017 Dec
-  list: 1 
+  list: 1
   position: 1
-  prospects: all_valid
-art_lib:
-  value: Art Library
-  list: 2 
-  position: 0
-science_lib:
-  value: Science Library
-  list: 2 
+may_2018:
+  value: 2018 May
+  list: 1
   position: 1
-engineering_lib:
-  value: Engineering Library
-  list: 2 
-  position: 2
-arch_lib:
+
+# Preferred Libraries
+architecture_library:
   value: Architecture Library
-  list: 2 
+  list: 2
   position: 3
-seventeen_spring:
+art_library:
+  value: Art Library
+  list: 2
+  position: 0
+engineering_library:
+  value: Engineering Library
+  list: 2
+  position: 2
+science_library:
+  value: Science Library
+  list: 2
+  position: 1
+
+# Semester
+spring_2017:
   value: Spring 2017
   list: 3
   position: 0
-seventeen_fall:
+fall_2017:
   value: Fall 2017
   list: 3
   position: 0
-eighteen_spring:
+spring_2018:
   value: Spring 2018
   list: 3
   position: 2

--- a/test/fixtures/prospects.yml
+++ b/test/fixtures/prospects.yml
@@ -1,10 +1,10 @@
 homeless:
   in_federal_study: true
   directory_id: hobo
-  first_name: Rolling 
+  first_name: Rolling
   last_name: Stone
   email: hobo@umd.edu
-  enumerations: graduate, seventeen_may, seventeen_fall 
+  enumerations: graduate, may_2017, fall_2017
 all_valid:
   in_federal_study: true
   directory_id: bstudent
@@ -13,12 +13,52 @@ all_valid:
   email: bstudent@umd.edu
   available_hours_per_week: 1
   available_times_count: 1
-  user_signature: All Valid  
-  enumerations: graduate, seventeen_dec, seventeen_fall 
+  user_signature: All Valid
+  enumerations: graduate, december_2017, fall_2017
 contact_info:
   in_federal_study: true
   directory_id: astudent
   first_name: Alvin
   last_name: Student
-  enumerations: undergraduate, seventeen_may, seventeen_fall 
+  enumerations: undergraduate, may_2017, fall_2017
   email: astudent@umd.edu
+
+filter_student_1:
+  in_federal_study: true
+  directory_id: filter_student_1
+  first_name: Filter
+  last_name: Student1
+  enumerations: undergraduate, may_2018, fall_2017, art_library
+  email: filter_student_1@umd.edu
+
+filter_student_2:
+  in_federal_study: true
+  directory_id: filter_student_2
+  first_name: Filter
+  last_name: Student2
+  enumerations: graduate, may_2018, fall_2017, art_library
+  email: filter_student_2@umd.edu
+
+filter_student_3:
+  in_federal_study: true
+  directory_id: filter_student_3
+  first_name: Filter
+  last_name: Student3
+  enumerations: undergraduate, may_2018, spring_2018, engineering_library
+  email: filter_student_3@umd.edu
+
+filter_student_4:
+  in_federal_study: true
+  directory_id: filter_student_4
+  first_name: Filter
+  last_name: Student4
+  enumerations: undergraduate, may_2018, spring_2018, science_library
+  email: filter_student_4@umd.edu
+
+filter_student_5:
+  in_federal_study: true
+  directory_id: filter_student_5
+  first_name: Filter
+  last_name: Student5
+  enumerations: graduate, may_2018, spring_2018, science_library
+  email: filter_student_5@umd.edu


### PR DESCRIPTION
Modified filtering so that different criteria types (Class Status,
Semester, Preferred Libraries, etc.) will be combined using "AND".
The resulting records must have a matching entry for each criteria type.

If multiple values within a criteria types are selected, the entries
for that type are combined using "OR", i.e., the resulting records must
have at least one of the selected entries.

The behavior of the "Available Times" criteria has not been changed --
multiple selections are "ANDed" together.

Fixed a minor typo in the app/views/prospects/_filter_modal.html.erb
that I found when working on test cases.

Added a few more prospects to the test fixtures, and renamed some of the
fixtures to be more consistent.

Removed "prospects" entries from "enumerations.yml" fixture, because
they do not appear to be necessary.

https://issues.umd.edu/browse/LIBITD-1219