### PR TITLE
LIBITD-1441. Modified slider max value to show all prospects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ group :test do
   gem 'minitest-reporters'
   # use the head to get the callback functionality
   gem 'capybara-screenshot'
-  gem 'chromedriver-helper'
+  gem 'webdrivers', '~> 3.9'
   gem 'database_cleaner'
   gem 'mocha'
   gem 'rack_session_access'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,6 @@ GEM
     airbrussh (1.1.2)
       sshkit (>= 1.6.1, != 1.7.0)
     ansi (1.5.0)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (6.0.4)
     ast (2.4.0)
     binding_of_caller (0.7.2)
@@ -82,9 +80,6 @@ GEM
       launchy
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (1.2.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     climate_control (0.2.0)
     cocoon (1.2.9)
     coderay (1.1.1)
@@ -141,7 +136,6 @@ GEM
       minitest (>= 3.0)
     i18n (0.7.0)
     i18n_data (0.7.0)
-    io-like (0.3.0)
     jbuilder (2.6.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -348,6 +342,10 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    webdrivers (3.9.4)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     will_paginate (3.1.5)
     will_paginate-bootstrap (1.0.1)
       will_paginate (>= 3.0.3)
@@ -362,7 +360,6 @@ DEPENDENCIES
   byebug
   capistrano-rails
   capybara-screenshot
-  chromedriver-helper
   cocoon
   connection_pool
   country_select
@@ -407,8 +404,9 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   umd_lib_style!
   web-console (~> 2.0)
+  webdrivers (~> 3.9)
   will_paginate (~> 3.1.0)
   will_paginate-bootstrap
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/app/models/prospect.rb
+++ b/app/models/prospect.rb
@@ -119,7 +119,20 @@ class Prospect < ActiveRecord::Base
 
   # the number of available hours per week should =< number of available_times
   validate :available_hours_per_week_gt_available_times
-  validates :available_hours_per_week, numericality: { greater_than_or_equal_to: 0 }
+  validate :available_hours_per_week_less_than_max
+
+  # Maximum number of available hours per week
+  def self.max_available_hours_per_week
+    50 # 7 days * 24 hours
+  end
+
+  def available_hours_per_week_less_than_max
+    if available_hours_per_week < 0
+      errors.add(:available_hours_per_week, 'must be greater than or equal to zero.')
+    elsif available_hours_per_week > max_available_hours_per_week
+      errors.add(:available_hours_per_week, "must be less than or equal to #{max_available_hours_per_week} hours.")
+    end
+  end
 
   # rubocop:disable Style/GuardClause
   def available_hours_per_week_gt_available_times

--- a/app/models/prospect.rb
+++ b/app/models/prospect.rb
@@ -123,14 +123,14 @@ class Prospect < ActiveRecord::Base
 
   # Maximum number of available hours per week
   def self.max_available_hours_per_week
-    50 # 7 days * 24 hours
+    168 # 7 days * 24 hours
   end
 
   def available_hours_per_week_less_than_max
     if available_hours_per_week < 0
       errors.add(:available_hours_per_week, 'must be greater than or equal to zero.')
-    elsif available_hours_per_week > max_available_hours_per_week
-      errors.add(:available_hours_per_week, "must be less than or equal to #{max_available_hours_per_week} hours.")
+    elsif available_hours_per_week > Prospect.max_available_hours_per_week
+      errors.add(:available_hours_per_week, "must be less than or equal to #{Prospect.max_available_hours_per_week} hours.")
     end
   end
 

--- a/app/views/prospects/_availability_step.html.erb
+++ b/app/views/prospects/_availability_step.html.erb
@@ -3,7 +3,8 @@
 <div class='panel panel-default'>
   <div class="panel-heading"><span>Total Available Hours Per Week</span></div>
   <div class="panel-body" id="basic-info">
-    <%= form.input :available_hours_per_week, required: true, input_html: { min: '0', step: 'any' } %>
+    <%= form.input :available_hours_per_week, required: true,
+                   input_html: { min: '0', max: @prospect.max_available_hours_per_week, step: 'any' } %>
   </div>
 </div>
 

--- a/app/views/prospects/_availability_step.html.erb
+++ b/app/views/prospects/_availability_step.html.erb
@@ -4,7 +4,7 @@
   <div class="panel-heading"><span>Total Available Hours Per Week</span></div>
   <div class="panel-body" id="basic-info">
     <%= form.input :available_hours_per_week, required: true,
-                   input_html: { min: '0', max: @prospect.max_available_hours_per_week, step: 'any' } %>
+                   input_html: { min: '0', max: Prospect.max_available_hours_per_week, step: 'any' } %>
   </div>
 </div>
 

--- a/app/views/prospects/_filter_modal.html.erb
+++ b/app/views/prospects/_filter_modal.html.erb
@@ -26,12 +26,13 @@
 
             <div class="row">
                 <h4>Available Hours</h4>
+                <% max_hours_per_week = Prospect.max_available_hours_per_week %>
                 <div class="col-md-8 availability-select">
                   <b>0</b><input id="available-hours-selector" type="text" class="span2" value="" data-slider-min="0"
-                  data-slider-max="50" data-slider-step="1"
-                  data-slider-value="[<%= params[:available_hours_per_week_min] || 0 %>,<%= params[:available_hours_per_week_max] || 50 %>]"/><b>50</b>
+                  data-slider-max="<%= max_hours_per_week %>" data-slider-step="1"
+                  data-slider-value="[<%= params[:available_hours_per_week_min] || 0 %>,<%= params[:available_hours_per_week_max] || max_hours_per_week %>]"/><b><%= max_hours_per_week %></b>
                  <%= hidden_field_tag( "available_hours_per_week_min", params[:available_hours_per_week_min] || 0, { id: 'availability-min' } ) %>
-                 <%= hidden_field_tag( "available_hours_per_week_max", params[:available_hours_per_week_max] || 50,{ id: 'availability-max' }) %>
+                 <%= hidden_field_tag( "available_hours_per_week_max", params[:available_hours_per_week_max] || max_hours_per_week, { id: 'availability-max' }) %>
                 </div>
             </div>
 

--- a/app/views/prospects/edit.html.erb
+++ b/app/views/prospects/edit.html.erb
@@ -5,7 +5,7 @@
     file: :horizontal_file_input,
     boolean: :horizontal_boolean
   } do |form| %>
-  <%= form.error_notification %> 
+  <%= form.error_notification %>
   <%= render 'id_and_semester_step', form: form %>
   <%= render 'contact_info_step', form: form %>
   <%= render 'work_experience_step', form: form %>

--- a/test/features/filter_available_hours_test.rb
+++ b/test/features/filter_available_hours_test.rb
@@ -24,7 +24,7 @@ feature 'Should be able filter prospects on available hours per week' do
     assert page.has_content?('Filter Applications')
 
     # we tweak the slider...
-    min = drag_until('.min-slider-handle', by: 100) { |v| v > 1 }
+    min = drag_until('.min-slider-handle', by: 10) { |v| v > 1 }
     max = drag_until('.max-slider-handle', by: -100) { |v| v < 40 }
     sleep(2)
     find("#submit-filter").click

--- a/test/features/sort_preserves_filter_test.rb
+++ b/test/features/sort_preserves_filter_test.rb
@@ -24,7 +24,7 @@ feature 'Should preserve filter query when sorting' do
     assert page.has_content?('Filter Applications')
 
     # we tweak the slider...
-    min = drag_until('.min-slider-handle', by: 100) { |v| v > 1 }
+    min = drag_until('.min-slider-handle', by: 10) { |v| v > 1 }
     max = drag_until('.max-slider-handle', by: -100) { |v| v < 40 }
     # wait for the changes to update before submitting
     sleep(2)


### PR DESCRIPTION
The "Filter" was only allowing a maximum of 50 hours to be selected, but the "Total Available Hours Per Week" selector in the application allows more than 50 hours to be selected.

Corrected this issue by adding a "max_available_hours_per_week" method to the "Prospect" model which sets the maximum number of hours that can be set in the application, and also uses it to set the maximum value for the slider in the "Filter" dialog.

Set the "max_available_hours_per_week" to 168 hours, so that any existing prospects that have already been entered will be displayed when the default Filter is used.

https://issues.umd.edu/browse/LIBITD-1441