### PR TITLE
LIBITD-2123. Bump "nokogiri" dependency to v1.13.4.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
       ruby2_keywords (~> 0.0.1)
     nenv (0.3.0)
     nio4r (2.5.8)
-    nokogiri (1.13.3)
+    nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notiffany (0.1.3)


### PR DESCRIPTION
Bumped the "nokogiri" dependency to v1.13.4 to fix a security
vulnerability identified by Dependabot.

https://issues.umd.edu/browse/LIBITD-2123