### PR TITLE
LIBITD-2710. Restrict access to the Resume "update" endpoint

### DIFF
--- a/app/controllers/resumes_controller.rb
+++ b/app/controllers/resumes_controller.rb
@@ -41,10 +41,17 @@ class ResumesController < ApplicationController
 
   def update
     @resume = Resume.includes(:prospect).find(params[:id])
-    if @resume.update(resume_params)
-      render json: @resume.to_json(except: :upload_session_id)
+
+    # Applicant can update their own resume within the same session, while
+    # logged-in users can update any resume
+    if same_session? || logged_in?
+      if @resume.update(resume_params)
+        render json: @resume.to_json(except: :upload_session_id)
+      else
+        render json: @resume.errors, status: :bad_request
+      end
     else
-      render json: @resume.errors, status: :bad_request
+      render plain: "forbidden", status: :forbidden, layout: false
     end
   end
 

--- a/test/controllers/resume_controller_test.rb
+++ b/test/controllers/resume_controller_test.rb
@@ -56,6 +56,17 @@ class ResumesControllerTest < ActionController::TestCase
     assert_response(400)
   end
 
+  test "should store the current session id in upload_session_id when creating a resume" do
+    post :create, params: { resume: { file: fixture_file_upload("resume.pdf", "application/pdf") } }
+    assert_response :success
+
+    resume = Resume.find(JSON.parse(response.body)["id"])
+
+    # Verifies that upload_session_id is populated from session.id on create
+    assert resume.upload_session_id.present?, "upload_session_id should not be blank"
+    assert_equal @request.session.id.to_s, resume.upload_session_id
+  end
+
   test "should NOT allow anyone not logged in to view an unsubmitted resume" do
     resume = Resume.create(file: { io: File.open("test/fixtures/files/resume.pdf"), filename: "resume.pdf" })
     get :show, params: { id: resume.id }
@@ -85,5 +96,74 @@ class ResumesControllerTest < ActionController::TestCase
     resume = Resume.create(file: { io: File.open("test/fixtures/files/resume.pdf"), filename: "resume.pdf" })
     get :show, params: { id: resume.id }
     assert_response :success
+  end
+
+  test "should NOT allow an unauthenticated user to update a resume uploaded in a different session" do
+    resume = Resume.create!(
+      file: { io: File.open("test/fixtures/files/resume.pdf"), filename: "resume.pdf" },
+      upload_session_id: "some-other-session-id" # simulates a resume owned by a different browser session
+    )
+
+    file = fixture_file_upload("resume spacey filename.pdf", "application/pdf")
+    patch :update, params: { id: resume.id, resume: { file: file } }
+
+    assert_response(403)
+
+    # Original file has not been changed
+    resume.reload
+    assert_equal "resume.pdf", resume.file.filename.to_s
+  end
+
+  test "should NOT allow an unauthenticated user with missing upload_session_id to update any resume" do
+    resume = Resume.create!(
+      file: { io: File.open("test/fixtures/files/resume.pdf"), filename: "resume.pdf" }
+      # upload_session_id intentionally left out
+    )
+
+    file = fixture_file_upload("resume spacey filename.pdf", "application/pdf")
+    patch :update, params: { id: resume.id, resume: { file: file } }
+
+    assert_response(403)
+
+    # Original file has not been changed
+    resume.reload
+    assert_equal "resume.pdf", resume.file.filename.to_s
+  end
+
+  test "should allow a student to update a resume they uploaded in the same session" do
+    # POST :create stores session.id in upload_session_id; reuse the same
+    # @request session for the subsequent PATCH to satisfy same_session?.
+    post :create, params: { resume: { file: fixture_file_upload("resume.pdf", "application/pdf") } }
+    assert_response :success
+
+    resume_id = JSON.parse(response.body)["id"]
+    resume = Resume.find_by(id: resume_id)
+    assert_equal "resume.pdf", resume.file.filename.to_s
+
+    file = fixture_file_upload("resume spacey filename.pdf", "application/pdf")
+    patch :update, params: { id: resume_id, resume: { file: file } }
+
+    assert_response :success
+
+    # Resume has been updated
+    resume.reload
+    assert_equal "resume spacey filename.pdf", resume.file.filename.to_s
+  end
+
+  test "should allow a logged-in user to update any resume" do
+    resume = Resume.create!(
+      file: { io: File.open("test/fixtures/files/resume.pdf"), filename: "resume.pdf" },
+      upload_session_id: "some-other-session-id"
+    )
+
+    session[:cas] = { user: "admin" }
+    file = fixture_file_upload("resume spacey filename.pdf", "application/pdf")
+    patch :update, params: { id: resume.id, resume: { file: file } }
+
+    assert_response :success
+
+    # Resume has been updated
+    resume.reload
+    assert_equal "resume spacey filename.pdf", resume.file.filename.to_s
   end
 end


### PR DESCRIPTION
This issue was identified by TerpAI in a security review of the “umd-lib/student-applications” codebase:

> **Likely unauthorized resume update**
> ResumesController#update appears to allow updating a resume without any visible authorization check.
>
> Risk: unauthorized file replacement or mutation.

Followed the convention in the show method to restrict the update method to only accept updates to a resume if the “session id” of the user matches the session id stored with the resume, or if a user is logged in.

Added controller tests to verify that the expected behavior:

* Applicants are able to update their resume within the same browser session of the submission
* Logged-in users are able to update any resume.

Co-authored-by: TerpAI <noreply@openai.com>
Co-authored-by: Perplexity AI <noreply@perplexity.ai>
https://umd-dit.atlassian.net/browse/LIBITD-2710