### PR TITLE
LIBITD-2712. Added Content Security Policy settings

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,26 +4,33 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Automatically add `nonce` to `javascript_tag`, `javascript_include_tag`, and `stylesheet_link_tag`
-#   # if the corresponding directives are specified in `content_security_policy_nonce_directives`.
-#   # config.content_security_policy_nonce_auto = true
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+# UMD Customization
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.base_uri    :self
+    policy.connect_src :self
+    policy.font_src    :self
+    policy.form_action :self
+    policy.frame_ancestors :none
+    policy.img_src     :self, :data
+    policy.object_src  :none
+    policy.script_src  :self
+    policy.script_src_attr :unsafe_inline # Required due to JQuery
+    policy.style_src :self, :unsafe_inline
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+  #
+  #   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+  #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  #   config.content_security_policy_nonce_directives = %w(script-src style-src)
+  #
+  #   # Automatically add `nonce` to `javascript_tag`, `javascript_include_tag`, and `stylesheet_link_tag`
+  #   # if the corresponding directives are specified in `content_security_policy_nonce_directives`.
+  #   # config.content_security_policy_nonce_auto = true
+  #
+  #   # Report violations without enforcing the policy.
+  #   # config.content_security_policy_report_only = true
+end
+# End UMD Customization

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,26 +4,33 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Automatically add `nonce` to `javascript_tag`, `javascript_include_tag`, and `stylesheet_link_tag`
-#   # if the corresponding directives are specified in `content_security_policy_nonce_directives`.
-#   # config.content_security_policy_nonce_auto = true
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+# UMD Customization
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.base_uri    :self
+    policy.connect_src :self
+    policy.font_src    :self
+    policy.form_action :self
+    policy.frame_ancestors :none
+    policy.img_src     :self, :data
+    policy.object_src  :none
+    policy.script_src  :self
+    policy.script_src_attr :unsafe_inline # Required due to JQuery
+    policy.style_src :self, :unsafe_inline # Required for inline styles (e.g., SSDR environment banner)
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+  #
+  #   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+  #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  #   config.content_security_policy_nonce_directives = %w(script-src style-src)
+  #
+  #   # Automatically add `nonce` to `javascript_tag`, `javascript_include_tag`, and `stylesheet_link_tag`
+  #   # if the corresponding directives are specified in `content_security_policy_nonce_directives`.
+  #   # config.content_security_policy_nonce_auto = true
+  #
+  #   # Report violations without enforcing the policy.
+  #   # config.content_security_policy_report_only = true
+end
+# End UMD Customization


### PR DESCRIPTION
Updated the Content Security Policy in line with recommendations
from TerpAI.

The main concessions to usability that are not ideal are:

* `policy.script_src_attr :unsafe_inline` - necessary because of event
  handlers added by JQuery 1.9.1. This is likely necessary until the
  application is moved to Bootstrap 5, or otherwise modified to update
  (or remove) JQuery.

* `policy.style_src   :self, :unsafe_inline` - necessary because of
  inline CSS styles (such as that used by the SSDR environment banner).


https://umd-dit.atlassian.net/browse/LIBITD-2712