### PR TITLE
LIBITD-2714. Fixes for intermittent system test failures

### DIFF
--- a/test/system/delayed_jobs_test.rb
+++ b/test/system/delayed_jobs_test.rb
@@ -10,9 +10,12 @@ class DelayedJobsTest < ApplicationSystemTestCase
     fill_in "password", with: "any password"
     click_button "Login"
 
-    visit "/delayed_jobs"
+    # Verify that login process has completed by checking for expected
+    # text on the page shown after login.
+    assert_text "Review Applications"
 
-    assert page.has_content?("Overview")
+    visit "/delayed_jobs"
+    assert_text "Overview"
   end
 
   test "nonadmins cannot see the delayed job page" do
@@ -22,13 +25,17 @@ class DelayedJobsTest < ApplicationSystemTestCase
     fill_in "password", with: "any password"
     click_button "Login"
 
+    # Verify that login process has completed by checking for expected
+    # text on the page shown after login.
+    assert_text "Review Applications"
+
     visit "/delayed_jobs"
 
-    assert page.has_content?("Unauthorized")
+    assert_text "Unauthorized"
   end
 
   test "unauthed visitors cannot see the delayed job page" do
     visit "/delayed_jobs"
-    assert page.has_content?("Unauthorized")
+    assert_text "Unauthorized"
   end
 end

--- a/test/system/support/selenium_error_patch.rb
+++ b/test/system/support/selenium_error_patch.rb
@@ -1,0 +1,60 @@
+# Taken from
+# https://github.com/alphagov/forms-admin/commit/5ea98767d765a396ed06cf2cba8f9afb1b10fc0e#diff-c36c07a0c7f499b1b95634f9dce1a10ebf4d10a9dee872f39f746a9efa555ddbR1-R34
+# via https://github.com/tf/pageflow/commit/238b32499a7455aa5e6ec3823addd252d75b4014
+# both of which use the MIT License
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2022 Crown Copyright (Government Digital Service)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Monkey patch for a specific intermittent Selenium error.
+#
+# Intermittently, Selenium/Chromedriver raises `Selenium::WebDriver::Error::UnknownError`
+# with the message "Node with given id does not belong to the document".
+
+# Capybara's automatic waiting/retrying mechanism doesn't catch it,
+# leading to failure.
+#
+# We intercept the initialization of `UnknownError`. If the message matches this specific
+# case, we raise a `StaleElementReferenceError` instead. This uses Capybara's
+# retry logic which makes doesn't fail the test
+#
+# This can be removed once the following issue is resolved:
+# https://github.com/teamcapybara/capybara/issues/2800
+#
+# taken from the following issue:
+# https://github.com/teamcapybara/capybara/issues/2800#issuecomment-3049956982
+module Selenium
+  module WebDriver
+    module Error
+      class UnknownError
+        alias_method :old_initialize, :initialize
+        def initialize(msg = nil)
+          if msg&.include?("Node with given id does not belong to the document")
+            raise StaleElementReferenceError, msg
+          end
+
+          old_initialize(msg)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## test/system/support/selenium_error_patch.rb

A Selenium ChromeDrive patch, taken from
https://github.com/tf/pageflow/commit/238b32499a7455aa5e6ec3823addd252d75b4014 that "fixes" intermittent system test failures related to a known Chrome/ChromeDriver race condition, starting in Chrome 134, in which Chrome’s DevTools protocol fires error code
`-32000 "Node with given id does not belong to the document"` because the browser does not wait for the next page load. This patch checks for the error, and triggers a retry, which appears to fix the problem.

See https://github.com/teamcapybara/capybara/issues/2800

Admittedly somewhat of a kludge, but attempts to improve the individual system tests based on suggestions for Perplexity AI were not consistently successful, so this seems to be the most practical solution at the moment.

## test/system/delayed_jobs_test.rb

After adding the “selenium_error_patch.rb” file, the “delayed_jobs_test.rb” file would still intermittently fail with the error:

```
 FAIL DelayedJobsTest#test_admins_can_see_the_delayed_job_page (128.65s)
        Expected false to be truthy.
        test/system/delayed_jobs_test.rb:15:in 'block in <class:DelayedJobsTest>'
```

This turns out to be a separate race condition between logging in (by clicking the “Login” button), and accessing the Delayed Web page. According to Perplexity:

The login form submits and redirects, but  click_button  returns as soon as the click is registered — not after the redirect and new page load complete. On a slow moment, the sequence looks like:

1) click_button "Login"  → POST submitted, redirect in flight
2) visit "/delayed_jobs"  → fires immediately, but Chrome is mid-redirect from step 1
3) Chrome resolves whichever navigation “wins” — sometimes /delayed_jobs, sometimes the login redirect lands on admin_prospects_path first
4) assert evaluates against whichever page ended up rendered

The fix was to ensure that the login process actually completed by adding an assert_text that checked for text that appears on admin page. Also changed the other assert page.has_content? calls to assert_text for consistency.

https://umd-dit.atlassian.net/browse/LIBITD-2714