### PR TITLE
LIBITD-2716. Limit access to admin-specific parameters

### DIFF
--- a/app/controllers/admin/prospects_controller.rb
+++ b/app/controllers/admin/prospects_controller.rb
@@ -47,6 +47,16 @@ module Admin
 
     private
 
+      # Extend the base whitelist with admin-only attributes for full admin
+      # users
+      def whitelisted_attrs
+        if @current_user.admin?
+          super + ProspectParameterHandling::ADMIN_ONLY_ATTRS
+        else
+          super
+        end
+      end
+
       def find_prospects # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         @all_results = Prospect.joins(join_table).select(select_statement)
                               .where(text_search_statement)

--- a/app/controllers/concerns/prospect_parameter_handling.rb
+++ b/app/controllers/concerns/prospect_parameter_handling.rb
@@ -64,8 +64,7 @@ module ProspectParameterHandling
       attrs = %i[
         current_step commit in_federal_study directory_id first_name last_name
         email class_status graduation_year additional_comments available_hours_per_week
-        resume_id user_confirmation user_signature class_status
-        major semester
+        resume_id user_confirmation user_signature major semester
       ]
       # these are has_many relationships that point to other pre-existing records
       has_many_ids = { enumeration_ids: [], day_times: [], skill_ids: [], library_ids: [] }

--- a/app/controllers/concerns/prospect_parameter_handling.rb
+++ b/app/controllers/concerns/prospect_parameter_handling.rb
@@ -5,6 +5,9 @@
 module ProspectParameterHandling
   extend ActiveSupport::Concern
 
+  # Admin-only fields - excluded from public whitelist
+  ADMIN_ONLY_ATTRS = %i[hired hr_comments suppressed].freeze
+
   private
 
     def log_exception(exception, prospect = nil)
@@ -61,8 +64,8 @@ module ProspectParameterHandling
       attrs = %i[
         current_step commit in_federal_study directory_id first_name last_name
         email class_status graduation_year additional_comments available_hours_per_week
-        resume_id user_confirmation user_signature class_status hired hr_comments
-        suppressed major semester
+        resume_id user_confirmation user_signature class_status
+        major semester
       ]
       # these are has_many relationships that point to other pre-existing records
       has_many_ids = { enumeration_ids: [], day_times: [], skill_ids: [], library_ids: [] }

--- a/app/controllers/prospects_controller.rb
+++ b/app/controllers/prospects_controller.rb
@@ -81,6 +81,13 @@ class ProspectsController < ApplicationController # rubocop:disable Metrics/Clas
     def set_session # rubocop:disable Metrics/AbcSize
       session[:prospect_params] ||= {}.with_indifferent_access
       session[:prospect_params].deep_merge!(prospect_params)
+
+      # Explicitly strip admin-only parameters from this user-facing set session
+      # Should already be taken care of by strong parameter handling in the
+      # "prospect_params" method of the ProspectParameterHandling concern, so
+      # this is just defense in depth
+      ProspectParameterHandling::ADMIN_ONLY_ATTRS.each { |k| session[:prospect_params].delete(k.to_s) }
+
       session[:prospect_params].keys.grep(/_attributes$/).each do |attr|
         session[:prospect_params][attr] = params[:prospect][attr] if params[:prospect][attr].present?
       end

--- a/test/controllers/admin/prospects_controller_test.rb
+++ b/test/controllers/admin/prospects_controller_test.rb
@@ -6,6 +6,38 @@ class Admin::ProspectsControllerTest < ActionController::TestCase
   tests Admin::ProspectsController
 
   # rubocop:disable Layout/LineLength
+  test "admin-only params are allowed when submitted by admin user" do
+    prospect = prospects(:all_valid)
+    all_valid_params = {}.with_indifferent_access
+    all_valid_params[:hired] = true
+    all_valid_params[:hr_comments] = "HR Comment submitted by admin"
+    all_valid_params[:suppressed] = true
+
+    session[:cas] = { user: "admin" }
+    patch :update, params: { id: prospect.id, prospect: all_valid_params }
+
+    prospect.reload
+    assert_equal true, prospect.hired, "'hired' should be settable by admin user"
+    assert_equal "HR Comment submitted by admin", prospect.hr_comments, "'hr_comments' should be settable by admin user"
+    assert_equal true, prospect.suppressed, "'suppressed' should be settable by admin user"
+  end
+
+  test "admin-only params are not settable by authed, but non-admin user" do
+    prospect = prospects(:all_valid)
+    all_valid_params = {}.with_indifferent_access
+    all_valid_params[:hired] = true
+    all_valid_params[:hr_comments] = "HR Comment submitted by admin"
+    all_valid_params[:suppressed] = true
+
+    session[:cas] = { user: "logged_in_but_not_full_admin" }
+    patch :update, params: { id: prospect.id, prospect: all_valid_params }
+
+    prospect.reload
+    assert_equal false, prospect.hired, "'hired' should not be settable by non-admin user"
+    assert_nil prospect.hr_comments, "'hr_comments' should not be settable by non-admin user"
+    assert_equal false, prospect.suppressed, "'suppressed' should not be settable by non-admin user"
+  end
+
   test "should allow authed users to deactivate a submitted application" do
     prospect = prospects(:all_valid)
     assert_not prospect.suppressed?
@@ -167,6 +199,7 @@ class Admin::ProspectsControllerTest < ActionController::TestCase
 
     address_attributes_param = ActionController::Parameters.new(address_attributes_hash)
     controller = Admin::ProspectsController.new
+    controller.instance_variable_set(:@current_user, users(:full_admin))
     result = controller.send(:convert_attributes_param_to_safe_hash, "addresses_attributes", address_attributes_param)
 
     assert result.key?("0")
@@ -197,6 +230,7 @@ class Admin::ProspectsControllerTest < ActionController::TestCase
 
     address_attributes_param = ActionController::Parameters.new(address_attributes_hash)
     controller = Admin::ProspectsController.new
+    controller.instance_variable_set(:@current_user, users(:full_admin))
     result = controller.send(:convert_attributes_param_to_safe_hash, "addresses_attributes", address_attributes_param)
 
     assert result.key?("0")

--- a/test/controllers/prospects_controller_test.rb
+++ b/test/controllers/prospects_controller_test.rb
@@ -83,5 +83,33 @@ class ProspectsControllerTest < ActionController::TestCase
     assert_equal "Anytown", result["1"]["city"]
     assert_not result["1"].key?("malicious_value")
   end
-  # rubocop:enable Layout/LineLength
+
+  test "admin-only params are ignored if submitted by applicant" do
+    # Set up parameters for a complete valid submission
+    fixture = dup_fixture
+    all_valid_params = fixture.attributes.with_indifferent_access
+    all_valid_params[:enumeration_ids] = fixture.enumerations.map(&:id)
+    all_valid_params.reject! { |a| %w[id created_at updated_at].include? a }
+
+    all_valid_params[:semester] = Enumeration.active_semesters.first.value
+
+    all_valid_params[:addresses_attributes] = [ addresses(:all_valid_springfield).attributes.reject { |a| a == "id" } ]
+    all_valid_params[:phone_numbers_attributes] = [ phone_numbers(:all_valid_dummy).attributes.reject { |a| a == "id" } ]
+    all_valid_params[:available_times_attributes] = [ available_times(:all_valid_sunday).attributes.reject { |a| a == "id" } ]
+
+    # Attempt to set admin-only parameters
+    all_valid_params[:hired] = true
+    all_valid_params[:hr_comments] = "HR Comment submitted by user"
+    all_valid_params[:suppressed] = true
+
+    session[:prospect_step] = Prospect.steps.last
+    post :create, params: { prospect: all_valid_params }
+
+    prospect = Prospect.find_by(directory_id: all_valid_params[:directory_id])
+
+    # Admin-only parameters have not been changed
+    assert_equal false, prospect.hired, "'hired' should not be settable by applicant"
+    assert_nil prospect.hr_comments, "'hr_comments' should not be settable by applicant"
+    assert_equal false, prospect.suppressed, "'suppressed' should not be settable by applicant"
+  end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,10 +1,13 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
+# User will full admin privileges
+full_admin:
   cas_directory_id: admin
   name: admin
   admin: true
 
-two:
-  cas_directory_id: noone
-  name: noone
+# Authorized user, without full admin privileges
+logged_in_but_not_full_admin:
+  cas_directory_id: logged_in_but_not_full_admin
+  name: logged_in_but_not_full_admin
+  admin: false


### PR DESCRIPTION
Removed admin-specific parameters from the list of allowed parameters
for user-based form submissions into a separate ADMIN_ONLY_ATTRS
array. User form submissions now ignore the "hired", "hr_comments",
and "suppressed" parameters. Also modified the "set_session" method
in the user ProspectsController to delete any ADMIN_ONLY_ATTRS parameters
in the user session (this is likely not strictly necessary, but is a
defensive backstop).

Modified the admin ProspectsController to allow the ADMIN_ONLY_ATTRS
parameters in form submissions by admins, so that the fields can
be edited.

Note: Only "full admins" should be able to change the "hired",
"hr_comments", and "suppressed" parameters -- applicants, and
non-logged in users should not.

Added tests for verifying admin-only params handling, and renamed the
"noone" user fixture to "logged_in_but_not_admin" to better
describe the user.

Removed a duplicated "class_status" in the attributes list, which
was unnecessary.

https://umd-dit.atlassian.net/browse/LIBITD-2716