### PR TITLE
LIBITD-2717. Fix Unescaped Database Values Interpolated into Raw SQL

### DIFF
--- a/app/controllers/concerns/querying_prospects.rb
+++ b/app/controllers/concerns/querying_prospects.rb
@@ -17,8 +17,10 @@ module QueryingProspects # rubocop:disable Metrics/ModuleLength
     klass, method = col.split(".")
     values = klass.singularize.capitalize.constantize.send(method.intern)
                   .order(Arel.sql("value #{sort_direction} ")).pluck("value")
+    conn = ActiveRecord::Base.connection
     order_query = values.each_with_index.inject(+"CASE ") do |memo, (val, i)| # rubocop:disable Style/EachWithObject
-      memo << "WHEN( enumerations.value = '#{val}') THEN #{i} "
+      safe_val = conn.quote(val)
+      memo << "WHEN( enumerations.value = #{safe_val} ) THEN #{i} "
       memo
     end
     Arel.sql("#{order_query} ELSE #{values.length} END")

--- a/test/controllers/admin/prospects_controller_test.rb
+++ b/test/controllers/admin/prospects_controller_test.rb
@@ -187,6 +187,20 @@ class Admin::ProspectsControllerTest < ActionController::TestCase
     end
   end
 
+  test "Enumerated value with single quote should not break sorting" do
+    Enumeration.create!(value: "Summer '26", list: :semester, position: 99)
+
+    session[:cas] = { user: "admin" }
+
+    begin
+      get :index, params: { sort: "enumerations.semester_values", direction: "asc" }
+    rescue ActiveRecord::StatementInvalid => e
+      flunk "Sorting raised a SQL error for a semester value containing a single quote: #{e.message}"
+    end
+
+    assert_response :success
+  end
+
   test "convert_attributes_param_to_safe_hash should allow only whitelisted parameters" do
     address_attributes_hash = {
       "0" => {


### PR DESCRIPTION
In the “sort_order” method of “querying_prospects.rb”, used the “ActiveRecord::Base.connection.quote” method to convert enumerated values into SQL-safe strings before generating the SQL query that sorts the records.

This prevents issues such as an enumerated value with a single quote, such as "Summer '26" from breaking the SQL query.

Co-authored-by: Perplexity AI <noreply@perplexity.ai>
https://umd-dit.atlassian.net/browse/LIBITD-2717