### PR TITLE
LIBITD-2719. Set config.active_storage.variant_processor to ":disabled"

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,10 @@ module OnlineStudentApplications
     config.rack_cas.session_store = RackCAS::ActiveRecordStore
 
     config.active_job.queue_adapter = :delayed_job
+
+    # Disable ActiveStorage thumbnail/image variant processing, because
+    # ActiveStorage is only used to upload resumes.
+    config.active_storage.variant_processor = :disabled
     # End UMD Customization
   end
 end


### PR DESCRIPTION
This is a minor cleanup issue, to fix the following message seen in the console log when running in Kubernetes:

> student-applications-app-0 student-applications Generating image
> variants require the image_processing gem. Please add gem
> "image_processing", "~> 1.2" to your Gemfile or set
> config.active_storage.variant_processor = :disabled.

Student Applications uses Active Storage only for uploading applicant resumes, and does not generate thumbnail images, so set the "variant_processor" to ":disabled"

https://umd-dit.atlassian.net/browse/LIBITD-2719