### PR TITLE
LIBITD-2722. Added "In Federal Work Study" filtering

### DIFF
--- a/app/controllers/admin/prospects_controller.rb
+++ b/app/controllers/admin/prospects_controller.rb
@@ -61,6 +61,7 @@ module Admin
         @all_results = Prospect.joins(join_table).select(select_statement)
                               .where(text_search_statement)
                               .where(search_statement)
+                              .where(prospects_in_federal_study)
                               .where(*available_range_statement)
                               .where(prospects_by_available_time)
                               .active.order(sort_order)

--- a/app/controllers/concerns/querying_prospects.rb
+++ b/app/controllers/concerns/querying_prospects.rb
@@ -102,6 +102,13 @@ module QueryingProspects # rubocop:disable Metrics/ModuleLength
       params[:available_time] ? { "prospects.id" => AvailableTime.find_by_sql(day_times_sql).map(&:prospect_id) } : {}
     end
 
+    def prospects_in_federal_study
+      value = params[:in_federal_study].to_s.downcase
+      return {} if value.blank? || value == "any"
+
+      { "prospects.in_federal_study" => value == "yes" }
+    end
+
     # Returns a query for the given enumeration type (as represented by the
     # method name on the Enumeration object)
     def enumeration_type_search_statement(enumeration_type) # rubocop:disable Metrics/AbcSize

--- a/app/views/admin/prospects/_filter_modal.html.erb
+++ b/app/views/admin/prospects/_filter_modal.html.erb
@@ -37,6 +37,28 @@
             </div>
 
             <div class="row">
+              <h4>In Federal Work Study</h4>
+              <div class="row">
+                <div class="col-md-12">
+                  <%= label_tag "in_federal_study_yes", class: "radio-inline" do %>
+                    <%= radio_button_tag :in_federal_study, "yes", params[:in_federal_study] == 'yes', id: 'in_federal_study_yes' %>
+                    Yes
+                  <% end %>
+
+                  <%= label_tag "in_federal_study_no", class: "radio-inline" do %>
+                    <%= radio_button_tag :in_federal_study, "no", params[:in_federal_study] == 'no', id: 'in_federal_study_no' %>
+                    No
+                  <% end %>
+
+                  <%= label_tag "in_federal_study_any", class: "radio-inline" do %>
+                    <%= radio_button_tag :in_federal_study, "any", (params[:in_federal_study].blank? || params[:in_federal_study] == 'any'), id: 'in_federal_study_any' %>
+                    Any
+                  <% end %>
+                </div>
+              </div>
+            </div>
+
+            <div class="row">
                 <h4>Semester</h4>
                 <% Enumeration.active_semesters.in_groups_of( 2 ) do |batch| %>
                   <div class="row">

--- a/test/fixtures/prospects.yml
+++ b/test/fixtures/prospects.yml
@@ -1,12 +1,12 @@
 homeless:
-  in_federal_study: true
+  in_federal_study: false
   directory_id: hobo
   first_name: Rolling
   last_name: Stone
   email: hobo@umd.edu
   enumerations: graduate, may_2017, fall_2017
 all_valid:
-  in_federal_study: true
+  in_federal_study: false
   directory_id: bstudent
   first_name: Betty
   last_name: Student

--- a/test/system/filter_in_federal_study_test.rb
+++ b/test/system/filter_in_federal_study_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class FilterInFederalStudyTest < ApplicationSystemTestCase
+  test "Should be able to filter prospects on federal work study" do
+    page.current_window.resize_to(2048, 9999)
+
+    User.create(cas_directory_id: "filterer", name: "filterer", admin: false)
+
+    students = Prospect.all.group_by(&:first_name).to_h { |k, v| [ k, v.first ] } # rubocop:disable Style/HashTransformValues
+
+    visit admin_prospects_path
+    fill_in "username", with: "filterer"
+    fill_in "password", with: "any password"
+    click_button "Login"
+
+    # We should have all of our students present
+    page.assert_selector("#prospect_#{students['Betty'].id}")
+    page.assert_selector("#prospect_#{students['Alvin'].id}")
+    page.assert_selector("#prospect_#{students['Rolling'].id}")
+
+    find("#filter-prospects").click
+    assert page.find("#filter-modal").visible?
+
+    # we select the 'Yes' radio button
+    find("input#in_federal_study_yes").click
+    assert find("input#in_federal_study_yes")["checked"]
+
+    find("#submit-filter").click
+    page.assert_selector("#filter-modal", visible: false)
+
+    # only alvin is in federal work study
+    page.assert_no_selector("#prospect_#{students['Betty'].id}")
+    page.assert_no_selector("#prospect_#{students['Rolling'].id}")
+    page.assert_selector("#prospect_#{students['Alvin'].id}")
+
+    # We search again
+    find("#filter-prospects").click
+    assert page.find("#filter-modal").visible?
+
+    # we select the 'No' radio button
+    find("input#in_federal_study_no").click
+    assert find("input#in_federal_study_no")["checked"]
+
+    find("#submit-filter").click
+    page.assert_selector("#filter-modal", visible: false)
+
+    # only betty and rolling are not in federal work study
+    page.assert_selector("#prospect_#{students['Betty'].id}")
+    page.assert_selector("#prospect_#{students['Rolling'].id}")
+    page.assert_no_selector("#prospect_#{students['Alvin'].id}")
+
+    # We search again
+    find("#filter-prospects").click
+    assert page.find("#filter-modal").visible?
+
+    # we select the 'Any' radio button
+    find("input#in_federal_study_any").click
+    assert find("input#in_federal_study_any")["checked"]
+
+    find("#submit-filter").click
+    page.assert_selector("#filter-modal", visible: false)
+
+    # all prospects are shown
+    page.assert_selector("#prospect_#{students['Betty'].id}")
+    page.assert_selector("#prospect_#{students['Rolling'].id}")
+    page.assert_selector("#prospect_#{students['Alvin'].id}")
+  end
+end


### PR DESCRIPTION
Added an "In Federal Work Study" section to the filter modal dialog in the admin interface, to enable filtering based on whether applicants are in a federal work study program.

The available options are:

* Yes - only applicants in federal work study will be shown
* No - only applicants *not* in federal work study will be shown
* Any - no filtering based on federal work study participation

https://umd-dit.atlassian.net/browse/LIBITD-2722