### PR TITLE
LIBITD-2725. Updated GUI labels for "In Federal Work Study" filter

### DIFF
--- a/app/views/admin/prospects/_filter_modal.html.erb
+++ b/app/views/admin/prospects/_filter_modal.html.erb
@@ -37,22 +37,22 @@
             </div>
 
             <div class="row">
-              <h4>In Federal Work Study</h4>
+              <h4>Federal Work Study Options</h4>
               <div class="row">
                 <div class="col-md-12">
                   <%= label_tag "in_federal_study_yes", class: "radio-inline" do %>
                     <%= radio_button_tag :in_federal_study, "yes", params[:in_federal_study] == 'yes', id: 'in_federal_study_yes' %>
-                    Yes
+                    Show only FWS students
                   <% end %>
 
                   <%= label_tag "in_federal_study_no", class: "radio-inline" do %>
                     <%= radio_button_tag :in_federal_study, "no", params[:in_federal_study] == 'no', id: 'in_federal_study_no' %>
-                    No
+                    Show only non-FWS students
                   <% end %>
 
                   <%= label_tag "in_federal_study_any", class: "radio-inline" do %>
                     <%= radio_button_tag :in_federal_study, "any", (params[:in_federal_study].blank? || params[:in_federal_study] == 'any'), id: 'in_federal_study_any' %>
-                    Any
+                    All Students
                   <% end %>
                 </div>
               </div>

--- a/app/views/admin/prospects/_filter_modal.html.erb
+++ b/app/views/admin/prospects/_filter_modal.html.erb
@@ -37,7 +37,7 @@
             </div>
 
             <div class="row">
-              <h4>Federal Work Study Options</h4>
+              <h4>Federal Work Study (FWS) Options</h4>
               <div class="row">
                 <div class="col-md-12">
                   <%= label_tag "in_federal_study_yes", class: "radio-inline" do %>
@@ -52,7 +52,7 @@
 
                   <%= label_tag "in_federal_study_any", class: "radio-inline" do %>
                     <%= radio_button_tag :in_federal_study, "any", (params[:in_federal_study].blank? || params[:in_federal_study] == 'any'), id: 'in_federal_study_any' %>
-                    All Students
+                    Show all students
                   <% end %>
                 </div>
               </div>


### PR DESCRIPTION
Updated the human-facing GUI labels:

* Changed "In Federal Work Study" heading to "Federal Work Study Options"

*  Changed filter options (From -> To):

* "Yes" -> "Show only FWS students"
* "No" -> "Show only non-FWS students"
* "Any" -> "All Students"

This change was made at the request of Dun Yee Wong in a June 11, 2026 email.

https://umd-dit.atlassian.net/browse/LIBITD-2725